### PR TITLE
Feat: make LspAttached callback more robust

### DIFF
--- a/lua/dropbar/sources/lsp.lua
+++ b/lua/dropbar/sources/lsp.lua
@@ -405,8 +405,7 @@ local function init()
     desc = 'Attach LSP symbol getter to buffer when an LS that supports documentSymbol attaches.',
     group = groupid,
     callback = function(info)
-      local client_id = (info.data or {}).client_id
-      local client = vim.lsp.get_client_by_id(client_id)
+      local client = vim.lsp.get_client_by_id(info.data and info.data.client_id)
       if client and client.supports_method('textDocument/documentSymbol') then
         attach(info.buf)
       end

--- a/lua/dropbar/sources/lsp.lua
+++ b/lua/dropbar/sources/lsp.lua
@@ -405,8 +405,9 @@ local function init()
     desc = 'Attach LSP symbol getter to buffer when an LS that supports documentSymbol attaches.',
     group = groupid,
     callback = function(info)
-      local client = vim.lsp.get_client_by_id(info.data.client_id)
-      if client.supports_method('textDocument/documentSymbol') then
+      local client_id = (info.data or {}).client_id
+      local client = vim.lsp.get_client_by_id(client_id)
+      if client and client.supports_method('textDocument/documentSymbol') then
         attach(info.buf)
       end
     end,

--- a/lua/dropbar/sources/lsp.lua
+++ b/lua/dropbar/sources/lsp.lua
@@ -405,7 +405,8 @@ local function init()
     desc = 'Attach LSP symbol getter to buffer when an LS that supports documentSymbol attaches.',
     group = groupid,
     callback = function(info)
-      local client = vim.lsp.get_client_by_id(info.data and info.data.client_id)
+      local client =
+        vim.lsp.get_client_by_id(info.data and info.data.client_id)
       if client and client.supports_method('textDocument/documentSymbol') then
         attach(info.buf)
       end


### PR DESCRIPTION
There seem be cases where a `LspAttach` event does not contain a `data` property with the client identifier inside. In such case the callback function would fail as it simply assumes this data structure to be given.
As it's still unclear why such events happen, it is quite easy to make the callback more robust. Therefore it checks if the data exists and it also verifies if a client could be found. In case that not, it simply does nothing and does not attach to it.

See also [this conversation](https://github.com/Bekaboo/dropbar.nvim/discussions/9#discussioncomment-6046818)