### PR TITLE
fix: wrap `nvim_win_get_buf` in pcall

### DIFF
--- a/lua/dropbar.lua
+++ b/lua/dropbar.lua
@@ -90,9 +90,12 @@ local function setup(opts)
       callback = function(info)
         local win = info.event == 'WinScrolled' and tonumber(info.match)
           or vim.api.nvim_get_current_win()
-        local buf = vim.api.nvim_win_get_buf(win)
+        local ok, buf = pcall(vim.api.nvim_win_get_buf, win)
+
         if
-          rawget(_G.dropbar.bars, buf) and rawget(_G.dropbar.bars[buf], win)
+          ok
+          and rawget(_G.dropbar.bars, buf)
+          and rawget(_G.dropbar.bars[buf], win)
         then
           _G.dropbar.bars[buf][win]:update()
         end


### PR DESCRIPTION
When using `folke/edgy.nvim`, the winid passed in here is sometimes invalid, leading to errors popping up when closing windows. Wrapping nvim_win_get_buf in pcall fixes the issue.