### PR TITLE
Fix several cross-platform issues with `path` 

### DIFF
--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -422,7 +422,7 @@ function dropbar_t:redraw()
 end
 
 ---Update dropbar components from sources and redraw dropbar, supposed to be
----called at CursorMoved, CurosrMovedI, TextChanged, and TextChangedI
+---called at CursorMoved, CursorMovedI, TextChanged, and TextChangedI
 ---Not updating when executing a macro
 ---@return nil
 function dropbar_t:update()

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -91,13 +91,13 @@ local function get_symbols(buf, win, _)
   local current_path = vim.fs.normalize(
     vim.fn.fnamemodify((vim.api.nvim_buf_get_name(buf)), ':p')
   )
+  local relative_to_path = vim.fs.normalize(
+    configs.eval(configs.opts.sources.path.relative_to, buf)
+  )
   while
     current_path ~= '.'
     and current_path ~= '/'
-    and current_path
-      ~= vim.fs.normalize(
-        configs.eval(configs.opts.sources.path.relative_to, buf)
-      )
+    and current_path ~= relative_to_path
   do
     table.insert(symbols, 1, convert(current_path, buf, win))
     current_path = vim.fs.dirname(current_path)

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -37,10 +37,20 @@ end
 ---@return dropbar_symbol_t
 local function convert(path, buf, win)
   local icon, icon_hl = get_icon(path)
+  local name = vim.fs.basename(path)
+  if name == '' then
+    -- We had a separator at the end of the path (because directory?).
+    name = vim.fs.dirname(path)
+    assert(string.sub(name, #name, #name) == '/', '`dirname` had no `/` at the end')
+    if #name > 1 then
+      -- We're on a platform like Windows that has more to a root name than just `/`, trim the `/`.
+      name = string.sub(name, 1, #name - 1)
+    end
+  end
   return bar.dropbar_symbol_t:new(setmetatable({
     buf = buf,
     win = win,
-    name = vim.fs.basename(path),
+    name = name,
     icon = icon,
     name_hl = 'DropBarKindFolder',
     icon_hl = icon_hl,

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -94,11 +94,18 @@ local function get_symbols(buf, win, _)
   local relative_to_path = vim.fs.normalize(
     configs.eval(configs.opts.sources.path.relative_to, buf)
   )
-  while
-    current_path ~= '.'
-    and current_path ~= '/'
-    and current_path ~= relative_to_path
-  do
+
+  local paths_up = function(path)
+    -- append a segment that will get immediately thrown away by `parents`
+    local dotted_path = path .. '/.'
+    return vim.iter(vim.fs.parents(dotted_path))
+  end
+
+  local current_paths_up = paths_up(current_path)
+  for up_path in current_paths_up do
+    if up_path == relative_to_path then
+      break
+    end
     table.insert(symbols, 1, convert(current_path, buf, win))
     current_path = vim.fs.dirname(current_path)
   end


### PR DESCRIPTION
Sorry, this is mostly a dump of code right now. The commits are fully fleshed-out, with explanatory commit messages where appropriate, but I don't feel like the current set of commits is fully justified yet. To summarize, the issues I'm trying to address are:

* Opening a file outside of the `relative_to` path (by default CWD) for the `path` source results in an infinite loop on Windows, because `current path == '/'` is _not_ sufficient for that platform. 😅
* It'd be nice to include root segments in paths outside of `relative_to`, since Windows can have multiple roots. It's also good for clarity on other platforms, too; a relative `usr/bin`, like when building a package for a Linux distro, is a _world_ of difference from an absolute `/usr/bin` path, for instance!
* Enumeration from root paths via `vim.fs.dir` is weirdly broken (at least on Windows), so I'm working around it by appending a `.` path segment.

Things left to do before I'd like to actually see this merged:

- [ ] `vim.fs.dir('C:/')` on Windows _should_ Just Work™, IMO (and obviate changes I've made for sibling and children generation), but for some reason, it doesn't. This sounds like an upstream issue, but I haven't taken any time to figure this out yet. I don't think this needs to be blocked on an upstream resolution, but I'd like to do due diligence here WRT identifying or filing a related issue/PR.
- [ ] I want to test this on *nix platforms, to make sure I haven't broken anything.