### PR TITLE
Fix highlighting issues and add some features in `sources.path`

### DIFF
--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -166,7 +166,8 @@ function dropbar_symbol_t:new(opts)
                     sym:merge({
                       name = '',
                       icon = menu_indicator_icon,
-                      icon_hl = 'DropBarIconUIIndicator',
+                      icon_hl = sym.data and sym.data.ui_icon_hl_override or
+                                'DropBarIconUIIndicator',
                       on_click = menu_indicator_on_click,
                     }),
                     sym:merge({

--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -640,15 +640,16 @@ function dropbar_t:update_current_context_hl(bar_idx)
   end
   local hl_currentcontext_icon = '_DropBarIconCurrentContext'
   local hl_currentcontext_name = '_DropBarCurrentContext'
+
   vim.api.nvim_set_hl(
     0,
     hl_currentcontext_icon,
-    utils.hl.merge('DropBarCurrentContext', symbol.icon_hl or 'WinBar')
+    utils.hl.merge(symbol.icon_hl or 'WinBar', 'DropBarCurrentContext')
   )
   vim.api.nvim_set_hl(
     0,
     hl_currentcontext_name,
-    utils.hl.merge('DropBarCurrentContext', symbol.name_hl or 'WinBar')
+    utils.hl.merge(symbol.name_hl or 'WinBar', 'DropBarCurrentContext')
   )
   symbol:swap_field('icon_hl', hl_currentcontext_icon)
   symbol:swap_field('name_hl', hl_currentcontext_name)
@@ -676,12 +677,12 @@ function dropbar_t:update_hover_hl(col)
   vim.api.nvim_set_hl(
     0,
     hl_hover_icon,
-    utils.hl.merge('DropBarHover', symbol.icon_hl or 'WinBar')
+    utils.hl.merge(symbol.icon_hl or 'WinBar', 'DropBarHover')
   )
   vim.api.nvim_set_hl(
     0,
     hl_hover_name,
-    utils.hl.merge('DropBarHover', symbol.name_hl or 'WinBar')
+    utils.hl.merge(symbol.name_hl or 'WinBar', 'DropBarHover')
   )
   symbol:swap_field('icon_hl', hl_hover_icon)
   symbol:swap_field('name_hl', hl_hover_name)

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -38,6 +38,10 @@ M.opts = {
       },
     },
   },
+  --***todo(theofabilous): update docs
+  highlight = {
+    background = nil,
+  },
   icons = {
     enable = true,
     kinds = {

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -2,6 +2,7 @@
 local hlgroups = {
   DropBarCurrentContext            = { link = 'Visual' },
   DropBarHover                     = { link = 'Visual' },
+
   DropBarIconKindArray             = { link = 'Array' },
   DropBarIconKindBoolean           = { link = 'Boolean' },
   DropBarIconKindBreakStatement    = { link = 'Error' },
@@ -65,6 +66,7 @@ local hlgroups = {
   DropBarIconKindValue             = { link = 'Number' },
   DropBarIconKindVariable          = { link = 'CmpItemKindVariable' },
   DropBarIconKindWhileStatement    = { link = 'Repeat' },
+
   DropBarIconUIIndicator           = { link = 'SpecialChar' },
   DropBarIconUIPickPivot           = { link = 'Error' },
   DropBarIconUISeparator           = { link = 'SpecialChar' },
@@ -77,14 +79,129 @@ local hlgroups = {
   DropBarMenuNormalFloat           = { link = 'NormalFloat' },
   DropBarPreview                   = { link = 'Visual' },
 }
+
+local kinds = {
+  "Array",
+  "Boolean",
+  "BreakStatement",
+  "Call",
+  "CaseStatement",
+  "Class",
+  "Constant",
+  "Constructor",
+  "ContinueStatement",
+  "Declaration",
+  "Delete",
+  "DoStatement",
+  "ElseStatement",
+  "Enum",
+  "EnumMember",
+  "Event",
+  "Field",
+  "File",
+  "Folder",
+  "ForStatement",
+  "Function",
+  "H1Marker",
+  "H2Marker",
+  "H3Marker",
+  "H4Marker",
+  "H5Marker",
+  "H6Marker",
+  "Identifier",
+  "IfStatement",
+  "Interface",
+  "Keyword",
+  "List",
+  "Macro",
+  "MarkdownH1",
+  "MarkdownH2",
+  "MarkdownH3",
+  "MarkdownH4",
+  "MarkdownH5",
+  "MarkdownH6",
+  "Method",
+  "Module",
+  "Namespace",
+  "Null",
+  "Number",
+  "Object",
+  "Operator",
+  "Package",
+  "Pair",
+  "Property",
+  "Reference",
+  "Repeat",
+  "Scope",
+  "Specifier",
+  "Statement",
+  "String",
+  "Struct",
+  "SwitchStatement",
+  "Type",
+  "TypeParameter",
+  "Unit",
+  "Value",
+  "Variable",
+  "WhileStatement",
+}
 -- stylua: ignore end
 
----Set winbar highlight groups
+---Set winbar highlight groups and override background if needed
 ---@return nil
 local function set_hlgroups()
-  for hl_name, hl_settings in pairs(hlgroups) do
-    hl_settings.default = true
-    vim.api.nvim_set_hl(0, hl_name, hl_settings)
+  local bg_hlgroup = require'dropbar.configs'.opts.highlight.background
+  if type(bg_hlgroup) ~= 'string' then
+    for hl_name, hl_settings in pairs(hlgroups) do
+      hl_settings.default = true
+      vim.api.nvim_set_hl(0, hl_name, hl_settings)
+    end
+    return
+  end
+
+  local bg_color = vim.api.nvim_get_hl(0, {
+    name = bg_hlgroup,
+    link = false,
+  }).bg
+
+  local ignore = {
+    "DropBarMenuFloatBorder",
+
+    "DropBarCurrentContext",
+    "DropBarMenuCurrentContext",
+    "DropBarHover",
+    "DropBarMenuHoverEntry",
+    "DropBarMenuHoverIcon",
+    "DropBarMenuHoverSymbol",
+
+    "DropBarPreview",
+  }
+
+  vim.api.nvim_set_hl(0, "WinBar", { bg = bg_color })
+  vim.api.nvim_set_hl(0, "WinBarNC", { bg = bg_color })
+
+  for hl_name, hl_info in pairs(hlgroups) do
+    if vim.tbl_contains(ignore, hl_name) then
+      hl_info.default = true
+    else
+      if hl_info.link then
+        hl_info = vim.api.nvim_get_hl(0, {
+          name = hl_info.link,
+          link = false,
+        })
+      end
+      hl_info = vim.tbl_extend('force', hl_info, {
+        default = true,
+        bg = bg_color
+      })
+    end
+    vim.api.nvim_set_hl(0, hl_name, hl_info)
+  end
+
+  -- ***note(theofabilous): initializing these groups at the beginning should 
+  -- probably be done regardless of whether or not the background is overridden
+  for _, kind in ipairs(kinds) do
+    vim.api.nvim_set_hl(0, 'DropBarKind' .. kind, { bg = bg_color })
   end
 end
 

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -71,6 +71,10 @@ local hlgroups = {
   DropBarIconUIPickPivot           = { link = 'Error' },
   DropBarIconUISeparator           = { link = 'SpecialChar' },
   DropBarIconUISeparatorMenu       = { link = 'DropBarIconUISeparator' },
+
+  -- ***todo(theofabilous): update docs
+  DropBarIconUISeparatorSpecial    = { link = 'Keyword' },
+
   DropBarMenuCurrentContext        = { link = 'PmenuSel' },
   DropBarMenuFloatBorder           = { link = 'FloatBorder' },
   DropBarMenuHoverEntry            = { link = 'Visual' },

--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -178,6 +178,7 @@ end
 ---@field clicked_at integer[]? last position where the menu was clicked, byte-indexed, 1,0-indexed
 ---@field prev_cursor integer[]? previous cursor position
 ---@field symbol_previewed dropbar_symbol_t? symbol being previewed
+---@field ns integer? highlight namespace
 local dropbar_menu_t = {}
 dropbar_menu_t.__index = dropbar_menu_t
 
@@ -318,7 +319,7 @@ function dropbar_menu_t:update_hover_hl(pos)
         },
         ['end'] = {
           line = pos[1] - 1,
-          character = range['end'],
+          character = range['end']-1, -- incluse range
         },
       }
     )
@@ -333,22 +334,29 @@ function dropbar_menu_t:update_current_context_hl(linenr)
   end
 end
 
----Add highlights to the menu buffer
+---Add highlights to the menu buffer and create namespace if not yet created
 ---@param hl_info dropbar_menu_hl_info_t[][]
 ---@return nil
 function dropbar_menu_t:add_hl(hl_info)
   if not self.buf then
     return
   end
+  ---***note(theofabilous): use a global namespace or one for each buf?
+  if not self.ns then
+    self.ns = vim.api.nvim_create_namespace('DropBarMenuBuf' .. tostring(self.buf))
+  end
+  vim.api.nvim_buf_clear_namespace(self.buf, self.ns, 0, -1)
   for linenr, hl_line_info in ipairs(hl_info) do
     for _, hl_symbol_info in ipairs(hl_line_info) do
-      vim.api.nvim_buf_add_highlight(
+      vim.highlight.range(
         self.buf,
-        hl_symbol_info.ns or -1,
+        hl_symbol_info.ns or self.ns --[[@as integer]],
         hl_symbol_info.hlgroup,
-        linenr - 1, -- 0-indexed
-        hl_symbol_info.start,
-        hl_symbol_info['end']
+        { linenr - 1, hl_symbol_info.start },
+        { linenr - 1, hl_symbol_info['end'] },
+        -- the priority is 1 less than the default priority in utils.hl.range_...
+        -- which allows the hover/context highlights to take precedence
+        { priority = vim.highlight.priorities.user, inclusive = false }
       )
     end
   end

--- a/lua/dropbar/sources/init.lua
+++ b/lua/dropbar/sources/init.lua
@@ -1,12 +1,12 @@
 ---@class dropbar_source_t
----@field get_symbols fun(buf: integer, win: integer, cursor: integer[]): dropbar_symbol_t[]
+---@field get_symbols fun(buf: integer, win: integer, cursor: integer[], ...): dropbar_symbol_t[]
 
 local notified = false
 
 ---For backword compatibility
----@param get_symbols fun(buf: integer, win: integer, cursor: integer[]): dropbar_symbol_t[]
+---@param get_symbols fun(buf: integer, win: integer, cursor: integer[], ...): dropbar_symbol_t[]
 ---@return dropbar_symbol_t[]
-local function check_params(get_symbols, buf, win, cursor)
+local function check_params(get_symbols, buf, win, cursor, ...)
   if
     type(buf) ~= 'number'
     or type(win) ~= 'number'
@@ -28,7 +28,7 @@ local function check_params(get_symbols, buf, win, cursor)
     end
     return {}
   end
-  return get_symbols(buf, win, cursor)
+  return get_symbols(buf, win, cursor, ...)
 end
 
 ---@type table<string, dropbar_source_t>
@@ -36,8 +36,8 @@ return setmetatable({}, {
   __index = function(self, key)
     local source = require('dropbar.sources.' .. key)
     local _get_symbols = source.get_symbols
-    source.get_symbols = function(buf, win, cursor)
-      return check_params(_get_symbols, buf, win, cursor)
+    source.get_symbols = function(buf, win, cursor, ...)
+      return check_params(_get_symbols, buf, win, cursor, ...)
     end
     self[key] = source
     return source

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -56,8 +56,18 @@ local function convert(path, buf, win)
         self.children = {}
         for name in vim.fs.dir(path) do
           if configs.opts.sources.path.filter(name) then
-            table.insert(self.children, convert(path .. '/' .. name, buf, win))
+            table.insert(
+              self.children,
+              convert(vim.fs.joinpath(path, name), buf, win)
+            )
           end
+        end
+        local path_is_dir = 1 == vim.fn.isdirectory(path)
+        if configs.opts.sources.path.filter('..') and path_is_dir then
+          table.insert(
+            self.children,
+            convert(vim.fs.joinpath(path, '..'), buf, win)
+          )
         end
         return self.children
       end
@@ -69,12 +79,18 @@ local function convert(path, buf, win)
           if configs.opts.sources.path.filter(name) then
             table.insert(
               self.siblings,
-              convert(parent_dir .. '/' .. name, buf, win)
+              convert(vim.fs.joinpath(parent_dir, name), buf, win)
             )
             if name == self.name then
               self.sibling_idx = idx
             end
           end
+        end
+        if configs.opts.sources.path.filter('..') then
+          table.insert(
+            self.siblings,
+            convert(vim.fs.joinpath(parent_dir, '..'), buf, win)
+          )
         end
         return self[k]
       end

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -68,6 +68,17 @@ local function convert(path, buf, win)
             self.children,
             convert(vim.fs.joinpath(path, '..'), buf, win)
           )
+        elseif not path_is_dir and (
+          vim.fs.normalize(path) ==
+          vim.fs.normalize(
+            vim.fn.fnamemodify((vim.api.nvim_buf_get_name(buf)), ':p')
+          )
+        ) then
+          local ts_symbols = require('dropbar.sources.treesitter')
+                            .get_symbols(buf, win, { 0, 0 }, { all_symbols = true })
+          vim.list_extend(self.children, ts_symbols)
+          self.data = self.data or {}
+          self.data.ui_icon_hl_override = 'DropBarIconUISeparatorSpecial'
         end
         return self.children
       end

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -1,5 +1,6 @@
 local configs = require('dropbar.configs')
 local bar = require('dropbar.bar')
+local hlgroups = require('dropbar.hlgroups')
 
 ---Get icon and icon highlight group of a path
 ---@param path string
@@ -24,7 +25,7 @@ local function get_icon(path)
         { default = true }
       )
       icon = devicon and devicon .. ' ' or icon
-      icon_hl = devicon_hl
+      icon_hl = hlgroups.get_devicon_hlgroup(devicon_hl)
     end
   end
   return icon, icon_hl


### PR DESCRIPTION
This PR changes quite a lot of code with regards to highlighting. Initially, the plan was to properly support setting a background colour but I encountered some other bugs along the way. I also added some features in `sources` which I address below. Each individual commit has an explanatory title and, when needed, a descriptive(imo) commit message, but given the amount of changes I feel the need to summarize and explain the changes here in a little more depth.

Scope
---

The scope of this PR is two-fold:
#### Highlighting issues

<details>
<summary>Properly support background highlighting</summary>
<br />

Commits f6509f83f9c36b37b3e7271023c131240ac866fb and 2e3e914468d9d0900bbf2f244983b71203e7abc0 address this. Prior to these commits, setting a background required manually overriding every highlight group with the desired background (and ignoring those that should not override the background, such as hover/context highlights). To remedy this, a highlight option is added to the config table, and the overriding of the background field is done in `set_hlgroups()`.

However setting a background breaks the highlighting of menu entries, which was fixed by using `vim.highlight.range()` instead of `nvim_buf_add_highlight()`. The former uses `extmarks` under the hood, and so `vim.highlight.priorities` can be used to combine highlight in a buffer without actually changing the highlight groups themselves. In the dropbar, the order of highlight group merging (in `:update_hover_hl()` and `:update_current_context_highlight()`) is reversed so that hover and context highlight attributes are prioritized.

Finally, setting a background requires tweaking the devicon highlights (see 2e3e914468d9d0900bbf2f244983b71203e7abc0, I think the commit message is sufficient).

---

</details>

<details> 

<summary>Fix updating of context and hover highlights when navigating menus</summary>
<br />

Commmit f3a600df673a2ede94953a25143ca053ca974c46 addresses this. **Here's a comparison of the behaviour before and after this change:**

<details> 
<summary>Before</summary>

> ![bad](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/79f827ba-0147-4037-9fb8-8ee7c8105f99)

</details>
<details> 

<summary>After</summary>

> ![good](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/08301d09-7dd0-4e21-b749-8770ed5d353e)

</details>

---

</details>

#### New features in `sources`

<details>

<summary>Add parent directory entry to `sources.path` </summary>
<br />

See 83f69feae1145c0f1ff55326a0e86a45728cc73b

---

</details>


<details>

<summary>Add top-level treesitter symbols as children to current file menu entry</summary>
<br />

See be115a377d6b5b9116334155c46ddf0b923d8aec. The commit message also presents the motivation for this feature.

> ![ts_symbols](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/4ad15474-602f-4a30-9c77-16de29e5b331)

---

</details>


Tasks
---


Before merging, I'd like to:

- [ ] Remove the `note` and `todo` comments
- [ ] Update the docs to reflect:
    - the new `DropBarIconUISeparatorSpecial` highlight group
    - ~~the highlight options in the config~~ [get background from `hl-WinBar`](https://github.com/Bekaboo/dropbar.nvim/pull/49#discussion_r1255002693)
- [ ] Possibly restructure/rework getting all the root treesitter symbols
    - To get the treesitter symbol children for the current file in be115a377d6b5b9116334155c46ddf0b923d8aec, a node has to first be found, and then its root must be found, at which point itself and its siblings are returned. The current [implementation](https://github.com/theofabilous/dropbar.nvim/blob/be115a377d6b5b9116334155c46ddf0b923d8aec/lua/dropbar/sources/treesitter.lua#L101-L154) might seem a little convoluted, this approach was taken because the more obvious approach (finding any node and getting its `:tree():root()` causes `neovim` to crash on my machine. Requires further investigation?
    - Further, getting all the symbols is implemented as an optional table argument to `sources.treesitter.get_symbols()`, which makes this function's signature differ from the other sources' `get_symbols()` functions. I'm considering creating a separate function for this instead, to keep consistency. For the moment I just changed `check_params()`/`get_symbols()` to take varargs so that they can transparently pass other arguments
- [ ] Format code, lint and test

