### PR TITLE
Support background highlight

### DIFF
--- a/lua/dropbar.lua
+++ b/lua/dropbar.lua
@@ -62,13 +62,32 @@ local function setup(opts)
       vim.wo.winbar = '%{%v:lua.dropbar.get_dropbar_str()%}'
     end
   end
+  local function _update_ns(buf, win, ns)
+    if configs.eval(configs.opts.general.enable, buf, win) then
+      vim.api.nvim_win_set_hl_ns(0, ns)
+    end
+  end
   for _, win in ipairs(vim.api.nvim_list_wins()) do
     _switch(vim.api.nvim_win_get_buf(win), win)
   end
+  vim.api.nvim_create_autocmd({ 'WinEnter', 'WinLeave' }, {
+    group = groupid,
+    callback = function(info)
+      _update_ns(
+        info.buf,
+        0,
+        info.event == 'WinEnter' and hlgroups.namespaces.current
+          or hlgroups.namespaces.nc
+      )
+    end,
+  })
   vim.api.nvim_create_autocmd({ 'OptionSet', 'BufWinEnter', 'BufWritePost' }, {
     group = groupid,
     callback = function(info)
       _switch(info.buf, 0)
+      if info.event == 'BufWinEnter' then
+        _update_ns(info.buf, 0, hlgroups.namespaces.current)
+      end
     end,
     desc = 'Enable/disable dropbar',
   })

--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -643,12 +643,12 @@ function dropbar_t:update_current_context_hl(bar_idx)
   vim.api.nvim_set_hl(
     0,
     hl_currentcontext_icon,
-    utils.hl.merge('DropBarCurrentContext', symbol.icon_hl or 'WinBar')
+    utils.hl.merge(symbol.icon_hl or 'WinBar', 'DropBarCurrentContext')
   )
   vim.api.nvim_set_hl(
     0,
     hl_currentcontext_name,
-    utils.hl.merge('DropBarCurrentContext', symbol.name_hl or 'WinBar')
+    utils.hl.merge(symbol.name_hl or 'WinBar', 'DropBarCurrentContext')
   )
   symbol:swap_field('icon_hl', hl_currentcontext_icon)
   symbol:swap_field('name_hl', hl_currentcontext_name)
@@ -676,12 +676,12 @@ function dropbar_t:update_hover_hl(col)
   vim.api.nvim_set_hl(
     0,
     hl_hover_icon,
-    utils.hl.merge('DropBarHover', symbol.icon_hl or 'WinBar')
+    utils.hl.merge(symbol.icon_hl or 'WinBar', 'DropBarHover')
   )
   vim.api.nvim_set_hl(
     0,
     hl_hover_name,
-    utils.hl.merge('DropBarHover', symbol.name_hl or 'WinBar')
+    utils.hl.merge(symbol.name_hl or 'WinBar', 'DropBarHover')
   )
   symbol:swap_field('icon_hl', hl_hover_icon)
   symbol:swap_field('name_hl', hl_hover_name)

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -167,17 +167,6 @@ local M = {
   managed = {},
 }
 
----Clear all created devicon highlight groups
----@return nil
-local function clear_devicon_hlgroups()
-  for hlname, _ in pairs(M.devicons) do
-    for _, ns in pairs(M.namespaces) do
-      vim.api.nvim_set_hl(ns, hlname, {})
-    end
-  end
-  M.devicons = {}
-end
-
 ---Create a highlight group with name `hl_name` and the given `hl_info`
 ---for each namespace
 ---@param hl_name string The name of the highlight group to create
@@ -221,8 +210,6 @@ end
 ---Set winbar highlight groups and override background if needed
 ---@return nil
 function M.set_hlgroups()
-  clear_devicon_hlgroups()
-
   M.dropbar.current = utils.hl.without('WinBar', { 'fg', 'nocombine' })
   if vim.tbl_isempty(M.dropbar.current) then
     M.dropbar.current = nil

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -163,6 +163,8 @@ local M = {
   },
   ---@type table<string, boolean>
   devicons = {},
+  ---@type table<string, boolean>
+  managed = {},
 }
 
 ---Clear all created devicon highlight groups
@@ -203,6 +205,17 @@ function M.get_devicon_hlgroup(hlgroup)
   create_hl(new_hlgroup, hlgroup)
   M.devicons[new_hlgroup] = true
   return new_hlgroup
+end
+
+---Register a non-dropbar defined highlight group to be managed by dropbar,
+---for example when setting icon/name highlights for symbols
+---@param hlgroup string
+---@return string: The managed highlight group name
+function M.manage(hlgroup)
+  M.managed[hlgroup] = true
+  local managed_hlgroup = 'DropBarManaged' .. hlgroup
+  create_hl(managed_hlgroup, hlgroup)
+  return managed_hlgroup
 end
 
 ---Set winbar highlight groups and override background if needed
@@ -265,6 +278,10 @@ function M.set_hlgroups()
 
   for _, kind in ipairs(kinds) do
     create_hl(kind, {})
+  end
+
+  for k, _ in pairs(M.managed) do
+    M.manage(k)
   end
 
   vim.api.nvim_set_hl(

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -77,14 +77,120 @@ local hlgroups = {
   DropBarMenuNormalFloat           = { link = 'NormalFloat' },
   DropBarPreview                   = { link = 'Visual' },
 }
+
+local kinds = {
+  "DropBarKindArray",
+  "DropBarKindBoolean",
+  "DropBarKindBreakStatement",
+  "DropBarKindCall",
+  "DropBarKindCaseStatement",
+  "DropBarKindClass",
+  "DropBarKindConstant",
+  "DropBarKindConstructor",
+  "DropBarKindContinueStatement",
+  "DropBarKindDeclaration",
+  "DropBarKindDelete",
+  "DropBarKindDoStatement",
+  "DropBarKindElseStatement",
+  "DropBarKindEnum",
+  "DropBarKindEnumMember",
+  "DropBarKindEvent",
+  "DropBarKindField",
+  "DropBarKindFile",
+  "DropBarKindFolder",
+  "DropBarKindForStatement",
+  "DropBarKindFunction",
+  "DropBarKindH1Marker",
+  "DropBarKindH2Marker",
+  "DropBarKindH3Marker",
+  "DropBarKindH4Marker",
+  "DropBarKindH5Marker",
+  "DropBarKindH6Marker",
+  "DropBarKindIdentifier",
+  "DropBarKindIfStatement",
+  "DropBarKindInterface",
+  "DropBarKindKeyword",
+  "DropBarKindList",
+  "DropBarKindMacro",
+  "DropBarKindMarkdownH1",
+  "DropBarKindMarkdownH2",
+  "DropBarKindMarkdownH3",
+  "DropBarKindMarkdownH4",
+  "DropBarKindMarkdownH5",
+  "DropBarKindMarkdownH6",
+  "DropBarKindMethod",
+  "DropBarKindModule",
+  "DropBarKindNamespace",
+  "DropBarKindNull",
+  "DropBarKindNumber",
+  "DropBarKindObject",
+  "DropBarKindOperator",
+  "DropBarKindPackage",
+  "DropBarKindPair",
+  "DropBarKindProperty",
+  "DropBarKindReference",
+  "DropBarKindRepeat",
+  "DropBarKindScope",
+  "DropBarKindSpecifier",
+  "DropBarKindStatement",
+  "DropBarKindString",
+  "DropBarKindStruct",
+  "DropBarKindSwitchStatement",
+  "DropBarKindType",
+  "DropBarKindTypeParameter",
+  "DropBarKindUnit",
+  "DropBarKindValue",
+  "DropBarKindVariable",
+  "DropBarKindWhileStatement",
+}
 -- stylua: ignore end
 
----Set winbar highlight groups
+---Set winbar highlight groups and override background if needed
 ---@return nil
 local function set_hlgroups()
-  for hl_name, hl_settings in pairs(hlgroups) do
-    hl_settings.default = true
-    vim.api.nvim_set_hl(0, hl_name, hl_settings)
+  local bg_color = vim.api.nvim_get_hl(0, {
+    name = 'WinBar',
+    link = false,
+  }).bg
+
+  if not bg_color then
+    for hl_name, hl_settings in pairs(hlgroups) do
+      hl_settings.default = true
+      vim.api.nvim_set_hl(0, hl_name, hl_settings)
+    end
+    return
+  end
+
+  local ignore = {
+    'DropBarCurrentContext',
+    'DropBarMenuCurrentContext',
+    'DropBarHover',
+    'DropBarMenuHoverEntry',
+    'DropBarMenuHoverIcon',
+    'DropBarMenuHoverSymbol',
+    'DropBarPreview',
+  }
+
+  for hl_name, hl_info in pairs(hlgroups) do
+    if vim.tbl_contains(ignore, hl_name) then
+      hl_info.default = true
+    else
+      if hl_info.link then
+        hl_info = vim.api.nvim_get_hl(0, {
+          name = hl_info.link,
+          link = false,
+        })
+      end
+      hl_info = vim.tbl_extend('force', hl_info, {
+        default = true,
+        bg = bg_color,
+      })
+    end
+    vim.api.nvim_set_hl(0, hl_name, hl_info)
+  end
+
+  for _, kind in ipairs(kinds) do
+    vim.api.nvim_set_hl(0, kind, { bg = bg_color })
   end
 end
 

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -145,10 +145,49 @@ local kinds = {
 }
 -- stylua: ignore end
 
+---@type integer?
+local bg_color = nil
+
+---@type table<string, boolean>
+local devicon_hlgroups = {}
+
+---Clear all created devicon highlight groups
+---@return nil
+local function clear_devicon_hlgroups()
+  for hlname, _ in pairs(devicon_hlgroups) do
+    vim.api.nvim_set_hl(0, hlname, {})
+  end
+  devicon_hlgroups = {}
+end
+
+---Get the patched highlight group for the given devicon highlight group or
+---the given highlight group if no background color is set
+---@param hlgroup string The highlight group to patch returned by get_icon()
+---@return string highlight group name
+local function get_devicon_hlgroup(hlgroup)
+  -- devicon hlgroups only need to be patched if a background color is set
+  if not bg_color then
+    return hlgroup
+  end
+  local new_hlgroup = 'DropBar' .. hlgroup
+  if devicon_hlgroups[new_hlgroup] then
+    return new_hlgroup
+  end
+
+  local new_hl_info =
+    require('dropbar.utils.hl').merge(hlgroup, { bg = bg_color })
+  vim.api.nvim_set_hl(0, new_hlgroup, new_hl_info)
+  devicon_hlgroups[new_hlgroup] = true
+
+  return new_hlgroup
+end
+
 ---Set winbar highlight groups and override background if needed
 ---@return nil
 local function set_hlgroups()
-  local bg_color = vim.api.nvim_get_hl(0, {
+  clear_devicon_hlgroups()
+
+  bg_color = vim.api.nvim_get_hl(0, {
     name = 'WinBar',
     link = false,
   }).bg
@@ -158,9 +197,11 @@ local function set_hlgroups()
       hl_settings.default = true
       vim.api.nvim_set_hl(0, hl_name, hl_settings)
     end
+    bg_color = nil
     return
   end
 
+  --- list of hlgroups that should keep their background color
   local ignore = {
     'DropBarCurrentContext',
     'DropBarMenuCurrentContext',
@@ -205,4 +246,5 @@ end
 
 return {
   init = init,
+  get_devicon_hlgroup = get_devicon_hlgroup,
 }

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -1,5 +1,6 @@
 local configs = require('dropbar.configs')
 local bar = require('dropbar.bar')
+local hlgroups = require('dropbar.hlgroups')
 
 ---Get icon and icon highlight group of a path
 ---@param path string
@@ -24,7 +25,7 @@ local function get_icon(path)
         { default = true }
       )
       icon = devicon and devicon .. ' ' or icon
-      icon_hl = devicon_hl
+      icon_hl = hlgroups.get_devicon_hlgroup(devicon_hl)
     end
   end
   return icon, icon_hl

--- a/lua/dropbar/utils/hl.lua
+++ b/lua/dropbar/utils/hl.lua
@@ -52,14 +52,17 @@ end
 
 ---Merge highlight attributes, use values from the right most hl group
 ---if there are conflicts
----@vararg string highlight group names
+---@vararg string|table highlight group names or attribute tables
 ---@return table merged highlight attributes
 function M.merge(...)
-  local hl_attr = vim.tbl_map(function(hl_name)
-    return vim.api.nvim_get_hl(0, {
-      name = hl_name,
-      link = false,
-    })
+  local hl_attr = vim.tbl_map(function(hl_info)
+    if type(hl_info) == 'string' then
+      return vim.api.nvim_get_hl(0, {
+        name = hl_info,
+        link = false,
+      })
+    end
+    return hl_info
   end, { ... })
   return vim.tbl_extend('force', unpack(hl_attr))
 end

--- a/lua/dropbar/utils/hl.lua
+++ b/lua/dropbar/utils/hl.lua
@@ -4,24 +4,32 @@ local M = {}
 ---@param buf integer
 ---@param hlgroup string
 ---@param range dropbar_symbol_range_t?
-function M.range_single(buf, hlgroup, range)
+---@param priority integer?
+function M.range_single(buf, hlgroup, range, priority)
   local ns = vim.api.nvim_create_namespace(hlgroup)
   vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
   if range then
-    for linenr = range.start.line, range['end'].line do
-      local start_col = linenr == range.start.line and range.start.character
-        or 0
-      local end_col = linenr == range['end'].line and range['end'].character
-        or -1
-      vim.api.nvim_buf_add_highlight(
-        buf,
-        ns,
-        hlgroup,
-        linenr,
-        start_col,
-        end_col
-      )
+    local end_col = range['end'].character
+    if end_col == -1 then
+      end_col = 1
+        + #vim.api.nvim_buf_get_lines(
+          buf,
+          range['end'].line,
+          range['end'].line + 1,
+          false
+        )[1]
     end
+    vim.highlight.range(
+      buf,
+      ns,
+      hlgroup,
+      { range.start.line, range.start.character },
+      { range['end'].line, end_col },
+      {
+        priority = priority or vim.highlight.priorities.user + 1,
+        inclusive = false,
+      }
+    )
   end
 end
 


### PR DESCRIPTION
*Originally part of #49*

This PR adds support for a background color on the dropbar. The changes made here are virtually identical to those in #49 (those that pertain to background highlighting), except that the highlight configuration option was removed, and the background color is [instead taken from `hl-WinBar`](https://github.com/Bekaboo/dropbar.nvim/pull/49#discussion_r1255002693). The commits were reorganized for clarity.

Tasks
---

- [x] Remove notes and todo comments
- [x] Run luacheck, stylua, check and pass tests
- [x] Ensure correctness of new `utils.hl.range_single()` which now uses `vim.highlight.range()` instead of `nvim_buf_add_highlight()`. `vim.highlight.range()` is a convenience wrapper for setting extmark highlights, which uses extmark indexing (different from api indexing and mark indexing). See [api-definitions](https://neovim.io/doc/user/api.html#api-definitions) right after the ext types table)
- [x] Add underline support (would close #2)

