### PR TITLE
Fix several highlighting issues that occur during menu navigation

### DIFF
--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -418,10 +418,7 @@ function dropbar_menu_t:make_buf()
     callback = function()
       local cursor = vim.api.nvim_win_get_cursor(self.win)
 
-      if
-        configs.opts.menu.preview
-        and not vim.deep_equal(cursor, self.prev_cursor)
-      then
+      if configs.opts.menu.preview then
         self:preview_symbol_at(cursor, true)
       end
 

--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -526,6 +526,14 @@ function dropbar_menu_t:close(restore_view)
   end
   -- Move cursor to the previous window
   if self.prev_win and vim.api.nvim_win_is_valid(self.prev_win) then
+    local prev_menu = _G.dropbar.menus[self.prev_win]
+    if prev_menu then
+      if prev_menu.cursor then
+        prev_menu:update_current_context_hl(prev_menu.cursor[1])
+      else
+        prev_menu:update_current_context_hl(nil)
+      end
+    end
     vim.api.nvim_set_current_win(self.prev_win)
   end
   -- Close the menu window and dereference it in the lookup table

--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -424,6 +424,8 @@ function dropbar_menu_t:make_buf()
 
       if configs.opts.menu.quick_navigation then
         self:quick_navigation(cursor)
+      else
+        self.prev_cursor = cursor
       end
 
       -- Update hover highlights


### PR DESCRIPTION
*Originally part of #49*

This fixes the updating of preview highlights when:
- closing a submenu and returning to a parent menu
- reopening a submenu that was previously closed

See the GIFs below for a comparison of the behavior before and after.

<details> 
<summary>Before</summary>

> ![bad](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/79f827ba-0147-4037-9fb8-8ee7c8105f99)

</details>
<details> 

<summary>After</summary>

> ![good](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/08301d09-7dd0-4e21-b749-8770ed5d353e)

</details>


This also fixes the updating of current context highlights when returning to a submenu. Prior to these changes, returning to a parent menu would retain the context highlight of the menu entry that was the parent.

Finally, the hover highlighting in menus would never update if quick navigation was disabled, which has been fixed.

Tasks
---

- [x] Failing one test in `menu_spec.lua`
