### PR TITLE
Sources features: add child entries to current file, add parent directory entry

### DIFF
--- a/doc/dropbar.txt
+++ b/doc/dropbar.txt
@@ -848,6 +848,7 @@ Highlight groups ~
   DropBarIconUIPickPivot             `{ link = 'Error' }`
   DropBarIconUISeparator             `{ link = 'SpecialChar' }`
   DropBarIconUISeparatorMenu         `{ link = 'DropBarIconUISeparator' }`
+  DropBarIconUISeparatorSpecial      `{ link = 'Keyword' }`
   DropBarMenuCurrentContext          `{ link = 'PmenuSel' }`
   DropBarMenuHoverEntry              `{ link = 'Visual' }`
   DropBarMenuHoverIcon               `{ reverse = true }`

--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -166,7 +166,8 @@ function dropbar_symbol_t:new(opts)
                     sym:merge({
                       name = '',
                       icon = menu_indicator_icon,
-                      icon_hl = 'DropBarIconUIIndicator',
+                      icon_hl = sym.data and sym.data.ui_icon_hl_override
+                        or 'DropBarIconUIIndicator',
                       on_click = menu_indicator_on_click,
                     }),
                     sym:merge({

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -69,6 +69,10 @@ local hlgroups = {
   DropBarIconUIPickPivot           = { link = 'Error' },
   DropBarIconUISeparator           = { link = 'SpecialChar' },
   DropBarIconUISeparatorMenu       = { link = 'DropBarIconUISeparator' },
+
+  -- ***todo(theofabilous): update docs
+  DropBarIconUISeparatorSpecial    = { link = 'Keyword' },
+
   DropBarMenuCurrentContext        = { link = 'PmenuSel' },
   DropBarMenuFloatBorder           = { link = 'FloatBorder' },
   DropBarMenuHoverEntry            = { link = 'Visual' },

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -69,10 +69,7 @@ local hlgroups = {
   DropBarIconUIPickPivot           = { link = 'Error' },
   DropBarIconUISeparator           = { link = 'SpecialChar' },
   DropBarIconUISeparatorMenu       = { link = 'DropBarIconUISeparator' },
-
-  -- ***todo(theofabilous): update docs
   DropBarIconUISeparatorSpecial    = { link = 'Keyword' },
-
   DropBarMenuCurrentContext        = { link = 'PmenuSel' },
   DropBarMenuFloatBorder           = { link = 'FloatBorder' },
   DropBarMenuHoverEntry            = { link = 'Visual' },

--- a/lua/dropbar/sources/init.lua
+++ b/lua/dropbar/sources/init.lua
@@ -1,24 +1,26 @@
 ---@class dropbar_source_t
----@field get_symbols fun(buf: integer, win: integer, cursor: integer[], ...): dropbar_symbol_t[]
+---@field get_symbols fun(buf: integer, win: integer, cursor: integer[], opts: table<string, any>?): dropbar_symbol_t[]
 
 local notified = false
 
 ---For backword compatibility
----@param get_symbols fun(buf: integer, win: integer, cursor: integer[], ...): dropbar_symbol_t[]
+---@param get_symbols fun(buf: integer, win: integer, cursor: integer[], opts: table<string, any>?): dropbar_symbol_t[]
 ---@return dropbar_symbol_t[]
-local function check_params(get_symbols, buf, win, cursor, ...)
+local function check_params(get_symbols, buf, win, cursor, opts)
   if
     type(buf) ~= 'number'
     or type(win) ~= 'number'
     or type(cursor) ~= 'table'
+    or opts ~= nil and type(opts) ~= 'table'
   then
     if not notified then
       vim.api.nvim_echo({
         { '[dropbar.nvim] ', 'Normal' },
-        { 'get_symbols() now accepts three parameters: ', 'Normal' },
+        { 'get_symbols() now accepts three to four parameters: ', 'Normal' },
         { '{buf}, ', 'Normal' },
         { '{win}, ', 'WarningMsg' },
-        { '{cursor} ', 'Normal' },
+        { '{cursor}, ', 'Normal' },
+        { '{opts}? ', 'MoreMsg' },
         { 'instead of two parameters: ', 'Normal' },
         { '{buf}, ', 'Normal' },
         { '{cursor}', 'Normal' },
@@ -28,7 +30,7 @@ local function check_params(get_symbols, buf, win, cursor, ...)
     end
     return {}
   end
-  return get_symbols(buf, win, cursor, ...)
+  return get_symbols(buf, win, cursor, opts)
 end
 
 ---@type table<string, dropbar_source_t>
@@ -36,8 +38,8 @@ return setmetatable({}, {
   __index = function(self, key)
     local source = require('dropbar.sources.' .. key)
     local _get_symbols = source.get_symbols
-    source.get_symbols = function(buf, win, cursor, ...)
-      return check_params(_get_symbols, buf, win, cursor, ...)
+    source.get_symbols = function(buf, win, cursor, opts)
+      return check_params(_get_symbols, buf, win, cursor, opts)
     end
     self[key] = source
     return source

--- a/lua/dropbar/sources/init.lua
+++ b/lua/dropbar/sources/init.lua
@@ -1,12 +1,12 @@
 ---@class dropbar_source_t
----@field get_symbols fun(buf: integer, win: integer, cursor: integer[]): dropbar_symbol_t[]
+---@field get_symbols fun(buf: integer, win: integer, cursor: integer[], ...): dropbar_symbol_t[]
 
 local notified = false
 
 ---For backword compatibility
----@param get_symbols fun(buf: integer, win: integer, cursor: integer[]): dropbar_symbol_t[]
+---@param get_symbols fun(buf: integer, win: integer, cursor: integer[], ...): dropbar_symbol_t[]
 ---@return dropbar_symbol_t[]
-local function check_params(get_symbols, buf, win, cursor)
+local function check_params(get_symbols, buf, win, cursor, ...)
   if
     type(buf) ~= 'number'
     or type(win) ~= 'number'
@@ -28,7 +28,7 @@ local function check_params(get_symbols, buf, win, cursor)
     end
     return {}
   end
-  return get_symbols(buf, win, cursor)
+  return get_symbols(buf, win, cursor, ...)
 end
 
 ---@type table<string, dropbar_source_t>
@@ -36,8 +36,8 @@ return setmetatable({}, {
   __index = function(self, key)
     local source = require('dropbar.sources.' .. key)
     local _get_symbols = source.get_symbols
-    source.get_symbols = function(buf, win, cursor)
-      return check_params(_get_symbols, buf, win, cursor)
+    source.get_symbols = function(buf, win, cursor, ...)
+      return check_params(_get_symbols, buf, win, cursor, ...)
     end
     self[key] = source
     return source

--- a/lua/dropbar/sources/lsp.lua
+++ b/lua/dropbar/sources/lsp.lua
@@ -379,8 +379,9 @@ local function init()
 end
 ---@param win integer window handler
 ---@param cursor integer[] cursor position
+---@param _ table<string, any>? options
 ---@return dropbar_symbol_t[] symbols dropbar symbols
-local function get_symbols(buf, win, cursor)
+local function get_symbols(buf, win, cursor, _)
   if not initialized then
     init()
   end

--- a/lua/dropbar/sources/markdown.lua
+++ b/lua/dropbar/sources/markdown.lua
@@ -272,8 +272,9 @@ end
 ---@param buf integer buffer handler
 ---@param win integer window handler
 ---@param cursor integer[] cursor position
+---@param _ table<string, any>? options, ignored
 ---@return dropbar_symbol_t[] symbols dropbar symbols
-local function get_symbols(buf, win, cursor)
+local function get_symbols(buf, win, cursor, _)
   if vim.bo[buf].filetype ~= 'markdown' then
     return {}
   end

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -115,12 +115,14 @@ local function convert(path, buf, win)
   }))
 end
 
+-- luacheck: push no unused args
 ---Get list of dropbar symbols of the parent directories of given buffer
 ---@param buf integer buffer handler
 ---@param win integer window handler
 ---@param _ integer[] cursor position, ignored
+---@param __ table<string, any>? options, ignored
 ---@return dropbar_symbol_t[] dropbar symbols
-local function get_symbols(buf, win, _)
+local function get_symbols(buf, win, _, __) ---@diagnostic disable-line unused-local
   local symbols = {} ---@type dropbar_symbol_t[]
   local current_path = vim.fs.normalize(
     vim.fn.fnamemodify((vim.api.nvim_buf_get_name(buf)), ':p')
@@ -141,6 +143,7 @@ local function get_symbols(buf, win, _)
   end
   return symbols
 end
+-- luacheck: pop
 
 return {
   get_symbols = get_symbols,

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -83,6 +83,8 @@ local function convert(path, buf, win)
             { all_symbols = true }
           )
           vim.list_extend(self.children, ts_symbols)
+          self.data = self.data or {}
+          self.data.ui_icon_hl_override = 'DropBarIconUISeparatorSpecial'
         end
         return self.children
       end

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -55,8 +55,18 @@ local function convert(path, buf, win)
         self.children = {}
         for name in vim.fs.dir(path) do
           if configs.opts.sources.path.filter(name) then
-            table.insert(self.children, convert(path .. '/' .. name, buf, win))
+            table.insert(
+              self.children,
+              convert(vim.fs.joinpath(path, name), buf, win)
+            )
           end
+        end
+        local path_is_dir = 1 == vim.fn.isdirectory(path)
+        if configs.opts.sources.path.filter('..') and path_is_dir then
+          table.insert(
+            self.children,
+            convert(vim.fs.joinpath(path, '..'), buf, win)
+          )
         end
         return self.children
       end
@@ -68,12 +78,18 @@ local function convert(path, buf, win)
           if configs.opts.sources.path.filter(name) then
             table.insert(
               self.siblings,
-              convert(parent_dir .. '/' .. name, buf, win)
+              convert(vim.fs.joinpath(parent_dir, name), buf, win)
             )
             if name == self.name then
               self.sibling_idx = idx
             end
           end
+        end
+        if configs.opts.sources.path.filter('..') then
+          table.insert(
+            self.siblings,
+            convert(vim.fs.joinpath(parent_dir, '..'), buf, win)
+          )
         end
         return self[k]
       end

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -67,6 +67,22 @@ local function convert(path, buf, win)
             self.children,
             convert(vim.fs.joinpath(path, '..'), buf, win)
           )
+        elseif
+          not path_is_dir
+          and (
+            vim.fs.normalize(path)
+            == vim.fs.normalize(
+              vim.fn.fnamemodify((vim.api.nvim_buf_get_name(buf)), ':p')
+            )
+          )
+        then
+          local ts_symbols = require('dropbar.sources.treesitter').get_symbols(
+            buf,
+            win,
+            { 0, 0 },
+            { all_symbols = true }
+          )
+          vim.list_extend(self.children, ts_symbols)
         end
         return self.children
       end

--- a/lua/dropbar/sources/treesitter.lua
+++ b/lua/dropbar/sources/treesitter.lua
@@ -118,6 +118,9 @@ local function get_first_node(buf)
     cursor[2] = cursor[2] + 1
     if cursor[2] >= col_count then
       cursor = { cursor[1] + 1, 0 }
+      if cursor[1] >= line_count then
+        return nil
+      end
       col_count = get_cols(cursor[1])
     end
   end


### PR DESCRIPTION
*Originally part of #49*

- Parent directory is now a menu entry for path source
- Current file menu entry has child entries, currently the top level treesitter symbols of the file

<details>
<summary> Demo </summary>

![ts_symbols](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/d08973d7-67f6-4d99-9266-20243bed7905)
</details>


In #49, I had expressed uncertainty with regards to adding an extra argument to `sources.treesitter.get_symbols()` because its signature would differ from the other `get_symbols()` for the other sources, and was considering instead creating a separate function dedicated to getting the top level TS nodes. However, given this comment (from https://github.com/Bekaboo/dropbar.nvim/pull/49#issuecomment-1624394416):
>   * in addition it would be great to add other sources, for example `lsp` & `markdown` as children to `path` source when appropriate (will look into this later)

it might be best to keep the functionality inside `get_symbols()`, since the other sources might require getting all the top level symbols as well, and so their signatures would end up being the same.

Tasks
---

- [x] Update docs to add new `DropBarIconUISeparatorSpecial` hlgroup
- [x] Remove todo and note comments
- ~~[x] ([original comment](https://github.com/Bekaboo/dropbar.nvim/pull/49#issuecomment-1624394416)) Possibly add more sources as children to current file~~
    - [x] related: adjust `check_params()` and `get_symbols()` signatures
- [x] Note sure about the `get_first_node()` implementation yet

