### PR TITLE
fix(dropbar): `WinResized` not updating all affected windows

### DIFF
--- a/lua/dropbar.lua
+++ b/lua/dropbar.lua
@@ -89,13 +89,21 @@ local function setup(opts)
     vim.api.nvim_create_autocmd(configs.opts.general.update_events.win, {
       group = groupid,
       callback = function(info)
-        local win = info.event == 'WinScrolled' and tonumber(info.match)
-          or vim.api.nvim_get_current_win()
-        local buf = vim.api.nvim_win_get_buf(win)
-        if
-          rawget(_G.dropbar.bars, buf) and rawget(_G.dropbar.bars[buf], win)
-        then
-          _G.dropbar.bars[buf][win]:update()
+        local windows
+        if info.event == 'WinScrolled' then
+          windows = { tonumber(info.match) }
+        elseif info.event == 'WinResized' then
+          windows = vim.v.event.windows
+        else
+          windows = { vim.api.nvim_get_current_win() }
+        end
+        for _, win in ipairs(windows) do
+          local buf = vim.api.nvim_win_get_buf(win)
+          if
+            rawget(_G.dropbar.bars, buf) and rawget(_G.dropbar.bars[buf], win)
+          then
+            _G.dropbar.bars[buf][win]:update()
+          end
         end
       end,
       desc = 'Update a single winbar.',


### PR DESCRIPTION
Prior to these changes, only one window would be updated on `WinResized` events. Also happens to fix something possibly related to #55: `WinResized` events from any window would cause the current window to update the dropbar. For example if an autocompletion plugin is installed like [nvim-cmp](https://github.com/hrsh7th/nvim-cmp), typing during insert mode triggers `WinResized` events on the popup menu which would update the dropbar.

<details>
<summary>Before</summary>

In this gif we can see that only the top left window's dropbar is updated.
![resize-all-bad](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/df566eee-9982-4641-ac8b-b3c112fc784e)

</details>

<details>
<summary>After</summary>

![resize-all-ok](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/2c50ba4c-be02-43ab-9218-be984a579e18)

</details>