### PR TITLE
fix: check if win is valid before updating

### DIFF
--- a/lua/dropbar.lua
+++ b/lua/dropbar.lua
@@ -98,11 +98,14 @@ local function setup(opts)
           windows = { vim.api.nvim_get_current_win() }
         end
         for _, win in ipairs(windows) do
-          local buf = vim.api.nvim_win_get_buf(win)
-          if
-            rawget(_G.dropbar.bars, buf) and rawget(_G.dropbar.bars[buf], win)
-          then
-            _G.dropbar.bars[buf][win]:update()
+          if vim.api.nvim_win_is_valid(win) then
+            local buf = vim.api.nvim_win_get_buf(win)
+            if
+              rawget(_G.dropbar.bars, buf)
+              and rawget(_G.dropbar.bars[buf], win)
+            then
+              _G.dropbar.bars[buf][win]:update()
+            end
           end
         end
       end,


### PR DESCRIPTION
Related to #32, but with a less dirty fix. 

The issue is not just with edgy.nvim, it seems to be a problem with many plugins that animate window movement. Whenever a window is closed closed mid-animation, it can become invalid in between the time that the window list is fetched and the time each window is updated because of the frequency of `WinResized` and`WinEnter` autocmds.  I don't want to disable those update events, and it may be an edge case but I think it's important to handle.