### PR TITLE
Feature: Fuzzy find dropbar menu entries

### DIFF
--- a/lua/dropbar/api.lua
+++ b/lua/dropbar/api.lua
@@ -1,3 +1,5 @@
+local configs = require('dropbar.configs')
+
 ---Get the dropbar
 ---@param buf? integer
 ---@param win integer
@@ -85,6 +87,62 @@ local function pick(idx)
   end
 end
 
+---Toggle fuzzy finding in current dropbar menu
+---@param opts table? fuzzy find options, ignored if closing fuzzy find
+local function fuzzy_find_toggle(opts)
+  local menu = get_current_dropbar_menu()
+  if not menu then
+    return
+  end
+  if menu.fzf_state then
+    menu:fuzzy_find_close(true)
+  else
+    menu:fuzzy_find_open(opts)
+  end
+end
+
+---Click on the currently selected fuzzy find menu entry, choosing the component
+---to click according to `component`.
+---
+---If `component` is a `number`, the `component`-nth symbol is selected, unless
+---`0` or `-1` is supplied, in which case the *first* or *last* clickable component
+---is selected, respectively. If it is a `function`, it receives the `dropbar_menu_entry_t`
+---as an argument and should return the `dropbar_symbol_t` that is to be clicked.
+---@param component? number|dropbar_symbol_t|fun(entry: dropbar_menu_entry_t):dropbar_symbol_t?
+local function fuzzy_find_click(component)
+  local menu = get_current_dropbar_menu()
+  if not menu or not menu.fzf_state then
+    return
+  end
+  menu:fuzzy_find_click_on_entry(component)
+end
+
+---Select the previous/next entry in the menu while fuzzy finding
+---@param direction "up" | "down"
+local function fuzzy_find_navigate(direction)
+  local menu = get_current_dropbar_menu()
+  if not menu or not menu.fzf_state then
+    return
+  end
+  local line_count = vim.api.nvim_buf_line_count(menu.buf)
+  if line_count <= 1 then
+    return
+  end
+  local cursor = vim.api.nvim_win_get_cursor(menu.win)
+  if direction == 'up' then
+    cursor[1] = math.max(1, cursor[1] - 1)
+  elseif direction == 'down' then
+    cursor[1] = math.min(line_count, cursor[1] + 1)
+  else
+    return
+  end
+  vim.api.nvim_win_set_cursor(menu.win, cursor)
+  menu:update_hover_hl(cursor)
+  if configs.opts.menu.preview then
+    menu:preview_symbol_at(cursor)
+  end
+end
+
 return {
   get_dropbar = get_dropbar,
   get_current_dropbar = get_current_dropbar,
@@ -93,4 +151,7 @@ return {
   goto_context_start = goto_context_start,
   select_next_context = select_next_context,
   pick = pick,
+  fuzzy_find_toggle = fuzzy_find_toggle,
+  fuzzy_find_click = fuzzy_find_click,
+  fuzzy_find_navigate = fuzzy_find_navigate,
 }

--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -178,6 +178,7 @@ end
 ---@field clicked_at integer[]? last position where the menu was clicked, byte-indexed, 1,0-indexed
 ---@field prev_cursor integer[]? previous cursor position
 ---@field symbol_previewed dropbar_symbol_t? symbol being previewed
+---@field fzf_state fzf_state_t? fuzzy-finding state, or nil if not currently fuzzy-finding
 local dropbar_menu_t = {}
 dropbar_menu_t.__index = dropbar_menu_t
 
@@ -356,15 +357,9 @@ function dropbar_menu_t:add_hl(hl_info)
   end
 end
 
----Make a buffer for the menu and set buffer-local keymaps
----Must be called after self:eval_win_configs()
----Side effect: change self.buf, self.hl_info
----@return nil
-function dropbar_menu_t:make_buf()
-  if self.buf then
-    return
-  end
-  self.buf = vim.api.nvim_create_buf(false, true)
+---Fill the menu buffer with entries in `self.entries` and add
+---highlights to the buffer
+function dropbar_menu_t:fill_buf()
   local lines = {} ---@type string[]
   local hl_info = {} ---@type dropbar_menu_hl_info_t[][]
   for _, entry in ipairs(self.entries) do
@@ -384,6 +379,18 @@ function dropbar_menu_t:make_buf()
   end
   vim.api.nvim_buf_set_lines(self.buf, 0, -1, false, lines)
   self:add_hl(hl_info)
+end
+
+---Make a buffer for the menu and set buffer-local keymaps
+---Must be called after self:eval_win_configs()
+---Side effect: change self.buf, self.hl_info
+---@return nil
+function dropbar_menu_t:make_buf()
+  if self.buf then
+    return
+  end
+  self.buf = vim.api.nvim_create_buf(false, true)
+  self:fill_buf()
   if self.cursor then
     self:update_current_context_hl(self.cursor[1])
   end
@@ -611,6 +618,313 @@ function dropbar_menu_t:quick_navigation(new_cursor)
     vim.api.nvim_win_set_cursor(self.win, new_cursor)
   end
   self.prev_cursor = new_cursor
+end
+
+---Restore menu buffer and entries in their original order
+---before modification by fuzzy finding
+---@version JIT
+function dropbar_menu_t:fuzzy_find_restore_entries()
+  if not self.fzf_state then
+    return
+  end
+  self.entries = {}
+  -- the order of the entries is changed as the entries are
+  -- sorted per their fzf score, but the idx field is preserved
+  for _, entry in ipairs(self.fzf_state.menu_entries) do
+    self.entries[entry.idx] = entry
+  end
+  self:fill_buf()
+end
+
+---Stop fuzzy finding and clean up allocated memory, optionally fixing the
+---cursor position to counteract cursor movement caused by entering and leaving
+---insert mode
+---@param fix_cursor boolean?
+---@version JIT
+function dropbar_menu_t:fuzzy_find_close(fix_cursor)
+  -- todo: handle case when restoring cursor
+  -- that only has one clickable component when
+  -- fixing the cursor (quick navigation?)
+  fix_cursor = fix_cursor == nil and true or fix_cursor
+  if not self.fzf_state then
+    return
+  end
+  if self.is_opened then
+    self:fuzzy_find_restore_entries()
+    vim.bo[self.buf].modifiable = false
+  end
+  local input_win = self.fzf_state.win
+  self.fzf_state:gc()
+  self.fzf_state = nil
+  if vim.api.nvim_win_is_valid(input_win) then
+    vim.cmd('silent! stopinsert')
+    vim.api.nvim_win_close(input_win, false)
+    if fix_cursor and self.is_opened then
+      vim.schedule(function()
+        local cursor = vim.api.nvim_win_get_cursor(0)
+        local new_col = math.min(cursor[2] + 1, vim.fn.col('$') - 2)
+        vim.api.nvim_win_set_cursor(0, { cursor[1], new_col })
+      end)
+    end
+  end
+  _G.dropbar.menus[input_win] = nil
+end
+
+---Click on the currently selected fuzzy find menu entry, choosing the component
+---to click according to `component`.
+---
+---If `component` is a `number`, the `component`-nth symbol is selected, unless
+---`0` or `-1` is supplied, in which case the *first* or *last* clickable component
+---is selected, respectively. If it is a `function`, it receives the `dropbar_menu_entry_t`
+---as an argument and should return the `dropbar_symbol_t` that is to be clicked.
+---@param component? number|dropbar_symbol_t|fun(entry: dropbar_menu_entry_t):dropbar_symbol_t?
+---@version JIT
+function dropbar_menu_t:fuzzy_find_click_on_entry(component)
+  if not self.fzf_state or vim.api.nvim_buf_line_count(self.buf) < 1 then
+    return
+  end
+  local cursor = vim.api.nvim_win_get_cursor(self.win)
+  local menu_entry = self.entries[cursor[1]]
+  if not menu_entry then
+    return
+  end
+  cursor[1] = menu_entry.idx
+  self:fuzzy_find_close(false)
+  vim.api.nvim_win_set_cursor(self.win, cursor)
+  vim.api.nvim_feedkeys('l', 'nt', false)
+  component = component or 0
+  vim.schedule(function()
+    local target
+    if type(component) == 'number' then
+      if component == -1 then
+        target = menu_entry.components[#menu_entry.components]
+        while target and not target.on_click do
+          target = menu_entry.components[target.entry_idx - 1]
+        end
+      elseif component == 0 then
+        cursor = vim.api.nvim_win_get_cursor(self.win)
+        target = menu_entry:first_clickable(cursor[2])
+      else
+        target = menu_entry.components[component]
+      end
+    elseif type(component) == 'function' then
+      target = component(menu_entry)
+    end
+    if not target or not target.on_click then
+      return
+    end
+    self:click_on(target, nil, 1, 'l')
+  end)
+end
+
+---Enable fuzzy finding mode
+---@param opts? table<string, any>
+---@version JIT
+function dropbar_menu_t:fuzzy_find_open(opts)
+  opts = vim.tbl_extend('keep', opts or {}, {
+    retain_inner_spaces = true,
+    char_pattern = '[%w%p]',
+    hl = {
+      fg = vim.api.nvim_get_hl(0, { name = 'htmlTag', link = false }).fg,
+      underline = true,
+    },
+    prompt = '%#htmlTag# ',
+  })
+
+  if not jit then
+    vim.notify('Fuzzy finding requires LuaJIT', vim.log.levels.ERROR)
+    return
+  elseif not utils.fzf then
+    vim.notify('fzf-lib is not installed', vim.log.levels.ERROR)
+    return
+  end
+
+  -- cache namespace
+  local fzf_lib = utils.fzf.fzf_lib
+
+  if self.fzf_state then
+    self:fuzzy_find_close(false)
+  end
+
+  local ns_name = 'DropBarFzf' .. tostring(self.win)
+  local augroup = vim.api.nvim_create_augroup(ns_name, { clear = true })
+  local ns_id = vim.api.nvim_create_namespace(ns_name)
+
+  vim.api.nvim_set_hl(0, 'DropBarFzfMatch', opts.hl)
+
+  vim.bo[self.buf].modifiable = true
+  local buf = vim.api.nvim_create_buf(false, true)
+  local win = vim.api.nvim_open_win(
+    buf,
+    false,
+    vim.tbl_extend('force', self._win_configs, {
+      row = self._win_configs.row + self._win_configs.height,
+      col = self._win_configs.col - 1,
+      height = 1,
+      border = 'single',
+    }, opts.win_configs or {})
+  )
+  vim.wo[win].stc = opts.prompt
+  _G.dropbar.menus[win] = self
+
+  local should_preview = configs.opts.menu.preview
+  local function move_cursor(pos)
+    vim.api.nvim_win_set_cursor(self.win, pos)
+    self:update_hover_hl(pos)
+    if should_preview then
+      self:preview_symbol_at(pos)
+    end
+  end
+
+  self.fzf_state = utils.fzf.fzf_state_t:new(self, win, opts)
+
+  local keymaps = vim.tbl_extend('force', {
+    ['<LeftMouse>'] = function()
+      local mouse = vim.fn.getmousepos()
+      if mouse.winid ~= self.win then
+        local default_func = configs.opts.menu.keymaps['<LeftMouse>']
+        if type(default_func) == 'function' then
+          default_func()
+        end
+        self:fuzzy_find_close(false)
+        return
+      elseif mouse.winrow > vim.api.nvim_buf_line_count(self.buf) then
+        return
+      end
+      vim.api.nvim_win_set_cursor(self.win, { mouse.line, mouse.column - 1 })
+      self:fuzzy_find_click_on_entry(function(entry)
+        return entry:get_component_at(mouse.column - 1, true)
+      end)
+    end,
+    ['<Esc>'] = function()
+      self:fuzzy_find_close(true)
+    end,
+    ['<Enter>'] = function()
+      self:fuzzy_find_click_on_entry(-1)
+    end,
+    ['<S-Enter>'] = function()
+      self:fuzzy_find_click_on_entry(nil)
+    end,
+    ['<Up>'] = function()
+      if vim.api.nvim_buf_line_count(self.buf) <= 1 then
+        return
+      end
+      local cursor = vim.api.nvim_win_get_cursor(self.win)
+      cursor[1] = math.max(1, cursor[1] - 1)
+      move_cursor(cursor)
+    end,
+    ['<Down>'] = function()
+      local line_count = vim.api.nvim_buf_line_count(self.buf)
+      if line_count <= 1 then
+        return
+      end
+      local cursor = vim.api.nvim_win_get_cursor(self.win)
+      cursor[1] = math.min(line_count, cursor[1] + 1)
+      move_cursor(cursor)
+    end,
+  }, opts.keymaps or {})
+
+  for key, func in pairs(keymaps) do
+    vim.keymap.set('i', key, func, { buffer = buf })
+  end
+
+  vim.api.nvim_set_current_win(win)
+  vim.schedule(function()
+    move_cursor({ 1, 1 })
+    vim.cmd('silent! startinsert')
+  end)
+
+  local function on_update()
+    if not self.fzf_state then
+      return true
+    end
+    ---@type fzf_state_t
+    local fzf_state = self.fzf_state
+    local text = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1]
+    if not text or #text < 1 then
+      vim.schedule(function()
+        self:fuzzy_find_restore_entries()
+        move_cursor({ 1, 1 })
+      end)
+      return
+    end
+    local pattern = fzf_lib.parse_pattern(text, 0, true)
+    for _, fzf_entry in ipairs(fzf_state.entries) do
+      fzf_entry.score =
+        fzf_lib.get_score(fzf_entry.str, pattern, fzf_state.slab)
+      fzf_entry.first = math.huge
+      if fzf_entry.score > 1 then
+        local positions =
+          fzf_lib.get_pos(fzf_entry.str, pattern, fzf_state.slab)
+        if positions and #positions > 0 then
+          fzf_entry.first = positions[1]
+          fzf_entry.pos = positions
+        end
+      end
+    end
+    fzf_lib.free_pattern(pattern)
+
+    table.sort(fzf_state.entries, function(a, b)
+      if a.score ~= b.score then
+        return a.score > b.score
+      elseif a.first ~= b.first then
+        return a.first < b.first
+      else
+        return a.index < b.index
+      end
+    end)
+    for i, fzf_entry in ipairs(fzf_state.entries) do
+      if fzf_entry.score > 1 then
+        self.entries[i] = fzf_state.menu_entries[fzf_entry.index]
+      else
+        self.entries[i] = nil
+        fzf_entry.pos = nil
+        fzf_entry.first = math.huge
+      end
+    end
+
+    vim.schedule(function()
+      vim.api.nvim_buf_clear_namespace(self.buf, ns_id, 0, -1)
+      self:fill_buf()
+      for i, fzf_entry in ipairs(fzf_state.entries) do
+        if fzf_entry.score >= 2 then
+          for _, pos_idx in ipairs(fzf_entry.pos) do
+            local pos = fzf_entry.locations[pos_idx]
+            vim.api.nvim_buf_set_extmark(self.buf, ns_id, i - 1, pos - 1, {
+              end_col = pos,
+              hl_group = 'DropBarFzfMatch',
+              priority = vim.highlight.priorities.user + 10,
+            })
+          end
+          fzf_entry.pos = nil
+        else
+          break
+        end
+      end
+      if #self.entries > 0 then
+        move_cursor({ 1, 1 })
+      else
+        if self.symbol_previewed then
+          self.symbol_previewed:preview_restore_hl()
+          self.symbol_previewed:preview_restore_view()
+          self.symbol_previewed = nil
+          self:update_hover_hl()
+        end
+      end
+    end)
+  end
+
+  vim.api.nvim_buf_attach(buf, false, { on_lines = on_update })
+
+  -- make sure allocated memory is freed (done in fuzzy_find_stop())
+  vim.api.nvim_create_autocmd({ 'BufUnload', 'BufWinLeave', 'WinLeave' }, {
+    group = augroup,
+    buffer = buf,
+    callback = function()
+      self:fuzzy_find_close(false)
+    end,
+    once = true,
+  })
 end
 
 ---Toggle the menu

--- a/lua/dropbar/utils/fzf.lua
+++ b/lua/dropbar/utils/fzf.lua
@@ -1,0 +1,121 @@
+-- If not built with LuaJIT, the ffi module will not be available,
+-- and neither will the fzf-native module (which is written in C and
+-- uses ffi).
+if not jit then
+  return nil
+end
+
+---@class fzf_lib_t
+---@field get_score
+---| fun(input: string, pattern: ffi.cdata*, slab: ffi.cdata*): number
+---@field get_pos
+---| fun(input: string, pattern: ffi.cdata*, slab: ffi.cdata*): nil|number[]
+---@field parse_pattern
+---| fun(pattern: string, case_mode: integer?, fuzzy: boolean): ffi.cdata*
+---@field free_pattern fun(pattern: ffi.cdata*)
+---@field allocate_slab fun(): ffi.cdata*
+---@field free_slab fun(slab: ffi.cdata*)
+local fzf_lib = (function()
+  local ok, lib = pcall(require, 'fzf_lib')
+  return ok and lib or nil
+end)()
+
+if not fzf_lib then
+  return nil
+end
+
+---@class fzf_entry_t
+---@field index integer
+---@field str string
+---@field locations integer[]
+---@field score integer
+---@field first integer
+---@field pos integer[]?
+
+---@class fzf_state_t
+---@field slab ffi.cdata*
+---@field menu_entries dropbar_menu_entry_t[]
+---@field entries fzf_entry_t[]
+---@field win integer
+---@field proxy userdata
+---@field num_entries integer
+local fzf_state_t = {}
+fzf_state_t.__index = fzf_state_t
+
+---Create a new `fzf_state_t`. This extracts the
+---@param menu dropbar_menu_t
+---@param win integer
+---@param opts table
+---@return fzf_state_t?
+---@version JIT
+function fzf_state_t:new(menu, win, opts)
+  local num_entries = #menu.entries
+  local char_pattern = opts.char_pattern
+  local entries = {}
+  local space_char = string.byte(' ')
+  local encountered_space = false
+  local retain_inner_spaces = opts.retain_inner_spaces
+  for i = 1, num_entries do
+    local char_idx = 1
+    local chars = {}
+    local locations = {}
+    local line = vim.api.nvim_buf_get_lines(menu.buf, i - 1, i, false)[1]
+    if not line then
+      return nil
+    end
+    local line_size = #line
+    local c = string.find(line, char_pattern)
+    while c and c <= line_size do
+      chars[char_idx] = line:sub(c, c)
+      locations[char_idx] = c
+      char_idx = char_idx + 1
+      c = c + 1
+      -- this is used to keep a single space (if any) between words, because fzf's
+      -- algorithm prioritizes patterns that are at word beginnings
+      if
+        retain_inner_spaces
+        and not encountered_space
+        and line:byte(c) == space_char
+      then
+        encountered_space = true
+      else
+        encountered_space = false
+        c = string.find(line, char_pattern, c)
+      end
+    end
+    entries[i] = {
+      locations = locations,
+      index = i,
+      str = table.concat(chars),
+      score = 0,
+    }
+  end
+  local state = setmetatable({
+    slab = fzf_lib.allocate_slab(),
+    menu_entries = { unpack(menu.entries) },
+    entries = entries,
+    win = win,
+    num_entries = num_entries,
+    proxy = newproxy(true),
+  }, self)
+  -- in lua 5.1, __gc metamethods are reserved for userdata
+  -- so we need to set it on a proxy object
+  getmetatable(state.proxy).__gc = function(_)
+    state:gc()
+  end
+  return state
+end
+
+---Free the memory allocated by the fuzzy finder
+---@version JIT
+function fzf_state_t:gc()
+  if self.slab ~= nil then
+    fzf_lib.free_slab(self.slab)
+  end
+  self.slab = nil
+end
+
+return {
+  fzf_lib = fzf_lib,
+  fzf_state_t = fzf_state_t,
+}


### PR DESCRIPTION
![fzf](https://github.com/Bekaboo/dropbar.nvim/assets/92238946/fc73b098-67d7-4e6c-a842-15dd084dd674)

Adds a fuzzy finding feature for dropbar menus using [telescope-fzf-native](https://github.com/nvim-telescope/telescope-fzf-native.nvim/).

Similar to #58, but uses mostly pure lua code, whereas #58 had lots of `ffi` calls, structs, etc. which made the changes much more complex.

Todo
---

- [ ] Mouse hover support (`mousemoveevent`)
- [ ] More/better configuration options
- [ ] Properly restore cursor column in menu when exiting fuzzy finding mode:
  - When entering and leaving insert mode, the cursor moves backwards by one char, so when leaving fzf and returning to menu, the cursor moves back, which can be hacked around by moving the cursor forward, but this has some weird behaviour with quick navigation enabled

Things I'm considering but may not implement:
- [ ] Recursive searching, i.e. search for the entries in the current menu AND their children, recursively