### PR TITLE
Fix: properly update highlights on colorscheme change

### DIFF
--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -196,6 +196,14 @@ function M.get_devicon_hlgroup(hlgroup)
   return new_hlgroup
 end
 
+---Update all patched devicon highlight groups to match the current dropbar
+---colors after a colorscheme change.
+local function update_devicon_hlgroups()
+  for created_hlgroup, _ in pairs(M.devicons) do
+    create_hl(created_hlgroup, created_hlgroup:sub(#'DropBar' + 1))
+  end
+end
+
 ---Register a non-dropbar defined highlight group to be managed by dropbar,
 ---for example when setting icon/name highlights for symbols
 ---@param hlgroup string
@@ -270,6 +278,8 @@ function M.set_hlgroups()
     'FloatBorder',
     { link = 'DropBarMenuFloatBorder', default = true }
   )
+
+  update_devicon_hlgroups()
 end
 
 ---Initialize highlight groups for dropbar
@@ -277,7 +287,7 @@ function M.init()
   M.set_hlgroups()
   vim.api.nvim_create_autocmd('ColorScheme', {
     group = vim.api.nvim_create_augroup('DropBarHlGroups', {}),
-    callback = M.set_hlgroups,
+    callback = vim.schedule_wrap(M.set_hlgroups),
   })
 end
 


### PR DESCRIPTION
Fixes incorrect highlight updates when colorscheme is changed. This is only relevant to this feature branch.

Prior to these changes, any "patched" devicon highlight was not "re-patched" when colorscheme is changed (by patched, I mean "create a separate highlight group for the devicon that inherits the winbar background highlights"). Now this is done.

Additionally, the `ColorScheme` autocmd event now *schedules* the updating of highlights instead of triggering it automatically. This is useful when the user sets some custom highlights after calling `:colorscheme`. Prior to this, if the user did something like:
```lua
vim.cmd('colorscheme <some colorscheme>')
vim.api.nvim_set_hl(0, 'WinBar', { ... })
```
the highlights would be created *before* the `WinBar` highlight is manually set, and thus not reflected in DropBar.
Now, since the update is *scheduled*, the above example would be reflected in DropBar highlights.