### PR TITLE
Fix: incorrect updating of previous window's highlight namespace

### DIFF
--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -461,12 +461,10 @@ function dropbar_menu_t:open_win()
   vim.api.nvim_win_set_hl_ns(self.win, hlgroups.namespaces.menu)
 
   if not _G.dropbar.menus[self.prev_win] then
-    vim.schedule(function()
-      local buf = vim.api.nvim_win_get_buf(self.prev_win)
-      if _G.dropbar.bars[buf][self.win] then
-        vim.api.nvim_win_set_hl_ns(self.prev_win, hlgroups.namespaces.current)
-      end
-    end)
+    local buf = vim.api.nvim_win_get_buf(self.prev_win)
+    if _G.dropbar.bars[buf][self.win] then
+      vim.api.nvim_win_set_hl_ns(self.prev_win, hlgroups.namespaces.current)
+    end
   end
 end
 

--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -462,7 +462,7 @@ function dropbar_menu_t:open_win()
 
   if not _G.dropbar.menus[self.prev_win] then
     local buf = vim.api.nvim_win_get_buf(self.prev_win)
-    if _G.dropbar.bars[buf][self.win] then
+    if _G.dropbar.bars[buf][self.prev_win] then
       vim.api.nvim_win_set_hl_ns(self.prev_win, hlgroups.namespaces.current)
     end
   end


### PR DESCRIPTION
Fixes correctness of highlight namespace updating when entering a new `dropbar_menu_t`. 

1. **Before**, this operation was `vim.schedule()`d which would fail if the `dropbar_menu_t` is closed immediately. The scheduling is removed and the namespace is updated immediately instead.
2. A check is done if the previous window is *not* a `dropbar_menu_t` (this is because we want to "force" the previous window to have the highlights of `WinBar` instead of `WinBarNC`, even thought we're technically *not* focused in that window). Then we check that window has, in fact, a DropBar (e.g. user could have some config that disables DropBar on that window, so in that case we don't want to update). **Before**, this check was being done with the wrong window handle, now the correct one is used.

The (1) also fixes *silent* errors in tests (i.e. vim would output error messages but tests still passed) because some tests closed menus immediately after trigger the scheduled operation in (1).

In #68, a test failed with `E325` which is vim saying that a swap file exists for a file that is being opened. Because the error messages related to (1) are apparent prior to this fail, I suspect this may fix that, but I'm not sure and can't reproduce that failure on my machine.