### PR TITLE
feat: add builtin source for terminal buffers

### DIFF
--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -7,7 +7,7 @@ M.opts = {
     ---@type boolean|fun(buf: integer, win: integer, info: table?): boolean
     enable = function(buf, win, _)
       return not vim.api.nvim_win_get_config(win).zindex
-        and vim.bo[buf].buftype == ''
+        and (vim.bo[buf].buftype == '' or vim.bo[buf].buftype == 'terminal')
         and vim.api.nvim_buf_get_name(buf) ~= ''
         and not vim.wo[win].diff
     end,
@@ -174,6 +174,11 @@ M.opts = {
             sources.markdown,
             sources.lsp,
           }),
+        }
+      end
+      if vim.bo[buf].buftype == 'terminal' then
+        return {
+          sources.terminal,
         }
       end
       return {
@@ -418,6 +423,23 @@ M.opts = {
         -- Number of lines to update when cursor moves out of the parsed range
         look_ahead = 200,
       },
+    },
+    terminal = {
+      ---@type string|fun(buf: integer): string
+      icon = function(buf)
+        local icon = M.opts.icons.kinds.symbols.Terminal
+        if M.opts.icons.kinds.use_devicons then
+          icon = require('nvim-web-devicons').get_icon_by_filetype(
+            vim.bo[buf].filetype
+          ) or icon
+        end
+        return icon
+      end,
+      ---@type string|fun(buf: integer): string
+      name = vim.api.nvim_buf_get_name,
+      ---@type boolean
+      ---Show the current terminal buffer in the menu
+      show_current = true,
     },
   },
 }

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -65,6 +65,7 @@ local hlgroups = {
   DropBarIconKindValue             = { link = 'Number' },
   DropBarIconKindVariable          = { link = 'CmpItemKindVariable' },
   DropBarIconKindWhileStatement    = { link = 'Repeat' },
+  DropBarIconKindTerminal          = { link = 'Number' },
   DropBarIconUIIndicator           = { link = 'SpecialChar' },
   DropBarIconUIPickPivot           = { link = 'Error' },
   DropBarIconUISeparator           = { link = 'SpecialChar' },

--- a/lua/dropbar/sources/terminal.lua
+++ b/lua/dropbar/sources/terminal.lua
@@ -1,0 +1,91 @@
+local initialized
+local configs
+
+local function init()
+  initialized = true
+  configs = require('dropbar.configs')
+end
+
+local function buf_info(buf)
+  local icon = configs.opts.sources.terminal.icon
+  if type(icon) == 'function' then
+    icon = icon(buf)
+  end
+  local name = configs.opts.sources.terminal.name
+  if type(name) == 'function' then
+    name = name(buf)
+  end
+  return {
+    icon = icon,
+    name = name,
+    icon_hl = 'DropBarIconKindTerminal',
+  }
+end
+
+---@param sym dropbar_symbol_t
+---@return dropbar_menu_entry_t[]
+local function get_menu_entries(sym)
+  return vim
+    .iter(vim.api.nvim_list_bufs())
+    :filter(function(buf)
+      return vim.bo[buf].buftype == 'terminal'
+        and (buf ~= sym.bar.buf or configs.opts.sources.terminal.show_current)
+    end)
+    :map(function(buf)
+      local entry = buf_info(buf)
+      entry.on_click = function()
+        vim.api.nvim_win_set_buf(sym.bar.win, buf)
+        sym.menu:close(true)
+      end
+      return require('dropbar.menu').dropbar_menu_entry_t:new({
+        components = {
+          require('dropbar.bar').dropbar_symbol_t:new(entry),
+        },
+      })
+    end)
+    :totable()
+end
+
+local function get_symbols(buf, win)
+  if not initialized then
+    init()
+  end
+
+  local symbol = buf_info(buf)
+  symbol.on_click = function(self)
+    local entries = get_menu_entries(self)
+    if #entries > 0 then
+      self.menu = require('dropbar.menu').dropbar_menu_t:new({
+        entries = entries,
+        prev_win = self.bar.win,
+      })
+      self.menu:open({
+        win_configs = {
+          win = win,
+          col = function(menu)
+            if menu.prev_menu then
+              return menu.prev_menu._win_configs.width
+            end
+            local mouse = vim.fn.getmousepos()
+            local bar = require('dropbar.api').get_dropbar(
+              vim.api.nvim_win_get_buf(menu.prev_win),
+              menu.prev_win
+            )
+            if not bar then
+              return 0
+            end
+            local _, range =
+              bar:get_component_at(math.max(0, mouse.wincol - 1))
+            return range and range.start or 0
+          end,
+        },
+      })
+    end
+  end
+
+  return {
+    require('dropbar.bar').dropbar_symbol_t:new(symbol),
+  }
+end
+
+return { get_symbols = get_symbols }


### PR DESCRIPTION
Allows using the dropdown menu to quickly switch between terminal buffers. Wrote this for my own config but figured I'd share since it's been useful.

All menu properties can be set to either strings or functions in the config, so it can be integrated easily with any terminal-related plugin. I have mine setup to use toggleterm. It will also work with default nvim terminal buffers.