### PR TITLE
fix(menu): allow `relative` win settings other than `win`

### DIFF
--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -490,6 +490,10 @@ function dropbar_menu_t:open_win()
   end
   self.is_opened = true
 
+  if self._win_configs.relative ~= 'win' then
+    self._win_configs.win = nil
+  end
+
   self.win = vim.api.nvim_open_win(self.buf, true, self._win_configs)
   vim.wo[self.win].scrolloff = 0
   vim.wo[self.win].sidescrolloff = 0
@@ -888,15 +892,20 @@ function dropbar_menu_t:fuzzy_find_open(opts)
     col_offset = 1
   end
 
-  local win = vim.api.nvim_open_win(
-    buf,
-    false,
+  local win_config =
     vim.tbl_extend('force', self._win_configs, opts.win_configs or {}, {
-      row = self._win_configs.row + self._win_configs.height,
-      col = self._win_configs.col - col_offset,
+      relative = 'win',
+      win = self.win,
+      row = self._win_configs.height,
+      col = col_offset,
       height = 1,
     })
-  )
+
+  -- don't show title in the fzf window
+  win_config.title = nil
+  win_config.title_pos = nil
+
+  local win = vim.api.nvim_open_win(buf, false, win_config)
   vim.wo[win].stc = opts.prompt
   _G.dropbar.menus[win] = self
   self.fzf_state = utils.fzf.fzf_state_t:new(self, win, opts)

--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -256,6 +256,10 @@ function dropbar_menu_t:eval_win_configs()
       self._win_configs[k] = config
     end
   end
+
+  if self._win_configs.relative ~= 'win' then
+    self._win_configs.win = nil
+  end
 end
 
 ---Get the component at the given position in the dropbar menu
@@ -489,10 +493,6 @@ function dropbar_menu_t:open_win()
     return
   end
   self.is_opened = true
-
-  if self._win_configs.relative ~= 'win' then
-    self._win_configs.win = nil
-  end
 
   self.win = vim.api.nvim_open_win(self.buf, true, self._win_configs)
   vim.wo[self.win].scrolloff = 0


### PR DESCRIPTION
Allows menus to be created with positions relative to `cursor`, `editor`, etc. 

Main reason for this is that I'm working on a `dropbar_menu_t` implementation of `vim.ui.select`.