### PR TITLE
feat(menu): allow showing virtual text below entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1973,6 +1973,7 @@ multiple `dropbar_menu_entry_t` instances while a
 | `separator`  | [`dropbar_symbol_t`](#dropbar_symbol_t)   | separator to use in the entry                                               |
 | `padding`    | `{left: integer, right: integer}`         | padding to use between the menu entry and the menu border                   |
 | `components` | [`dropbar_symbol_t[]`](#dropbar_symbol_t) | components<sub>[`dropbar_symbol_t[]`](#dropbar_symbol_t)</sub> in the entry |
+| `virt_text`  | `string[][]?`                             | list of virtual text chunks to display below the entry                      |
 | `menu`       | [`dropbar_menu_t?`](#dropbar_menu_t)      | the menu the entry belongs to                                               |
 | `idx`        | `integer?`                                | the index of the entry in the menu                                          |
 

--- a/doc/dropbar.txt
+++ b/doc/dropbar.txt
@@ -1832,21 +1832,21 @@ contain multiple `dropbar_symbol_t` instances.
 
 `dropbar_menu_entry_t` has the following fields:
 
-dropbar_menu_t.separator                            *dropbar_menu_t.separator*
+dropbar_menu_entry_t.separator                      *dropbar_menu_t.separator*
 
  	Separator to use in the entry
 
 	Type ~
 	    `dropbar_symbol_t`
 
-dropbar_menu_t.padding                                *dropbar_menu_t.padding*
+dropbar_menu_entry_t.padding                          *dropbar_menu_t.padding*
 
  	Padding to use between the menu entry and the menu border
 
 	Type ~
 	    { left: integer, right: integer }
 
-dropbar_menu_t.components                          *dropbar_menu_t.components*
+dropbar_menu_entry_t.components                    *dropbar_menu_t.components*
 
 	Symbols got from sources |dropbar-developers-classes-dropbar_source_t|
 	in the entry
@@ -1854,14 +1854,22 @@ dropbar_menu_t.components                          *dropbar_menu_t.components*
 	Type ~
 	    `dropbar_symbol_t`[]
 
-dropbar_menu_t.menu                                      *dropbar_menu_t.menu*
+dropbar_menu_entry_t.virt_text                      *dropbar_menu_t.virt_text*
+
+	Symbols got from sources |dropbar-developers-classes-dropbar_source_t|
+	in the entry
+
+	Type ~
+	    `string`[][]?
+
+dropbar_menu_entry_t.menu                                *dropbar_menu_t.menu*
 
  	The menu the entry belongs to
 
 	Type ~
 	    `dropbar_menu_t`?
 
-dropbar_menu_t.idx                                        *dropbar_menu_t.idx*
+dropbar_menu_entry_t.idx                                  *dropbar_menu_t.idx*
 
  	The index of the entry in the menu
 

--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -423,7 +423,7 @@ function dropbar_menu_t:fill_buf()
   vim.api.nvim_buf_set_lines(self.buf, 0, -1, false, lines)
   self:add_hl(hl_info)
 
-  local extmark_ns = vim.api.nvim_create_namespace('dropbar_extmarks')
+  local extmark_ns = vim.api.nvim_create_namespace('DropBarExtmarks')
   vim.api.nvim_buf_clear_namespace(self.buf, extmark_ns, 0, -1)
 
   for i, virt_text in pairs(extmarks) do


### PR DESCRIPTION
This PR adds the ability to show `virt_text` below each menu entry:

https://github.com/Bekaboo/dropbar.nvim/assets/38540736/b8d0523d-484e-45f7-8572-aab9e48afea1


