### PR TITLE
fix(fzf): ensure `fzf_entry.pos` is non-nil in `on_update`

### DIFF
--- a/lua/dropbar/menu.lua
+++ b/lua/dropbar/menu.lua
@@ -1038,7 +1038,7 @@ function dropbar_menu_t:fuzzy_find_open(opts)
         end
       end
       for i, fzf_entry in ipairs(fzf_state.entries) do
-        if fzf_entry.score >= 2 then
+        if fzf_entry.score >= 2 and fzf_entry.pos then
           for _, pos_idx in ipairs(fzf_entry.pos) do
             local pos = fzf_entry.locations[pos_idx]
             vim.api.nvim_buf_set_extmark(self.buf, ns_id, i - 1, pos - 1, {


### PR DESCRIPTION
problem: since a large portion of `on_update` is inside of a `vim.schedule` closure - if all input buffer text is removed quickly, fzf entries can have their `pos` field removed before the `vim.schedule` callback executes, causing an error. solution: add a check to ensure that `fzf_entry.pos` is not nil before iterating and setting extmarks

fixes #97