### PR TITLE
fix: fatal with invalid buffer

### DIFF
--- a/lua/dropbar/sources/markdown.lua
+++ b/lua/dropbar/sources/markdown.lua
@@ -30,7 +30,7 @@ end
 ---@field symbols markdown_heading_symbol_t[]
 local markdown_heading_symbols_parsed_list_t = {}
 markdown_heading_symbols_parsed_list_t.__index =
-  markdown_heading_symbols_parsed_list_t
+    markdown_heading_symbols_parsed_list_t
 
 ---Create a new markdown heading symbols parsed object
 ---@param opts markdown_heading_symbols_parsed_list_t?
@@ -49,7 +49,7 @@ local markdown_heading_buf_symbols = {}
 setmetatable(markdown_heading_buf_symbols, {
   __index = function(_, k)
     markdown_heading_buf_symbols[k] =
-      markdown_heading_symbols_parsed_list_t:new()
+        markdown_heading_symbols_parsed_list_t:new()
     return markdown_heading_buf_symbols[k]
   end,
 })
@@ -68,13 +68,17 @@ local function parse_buf(buf, lnum_end, incremental)
     symbols_parsed.symbols = {}
     symbols_parsed['end'] = { lnum = 0, inside_code_block = false }
   end
+  -- if buf is invalid, return
+  if not vim.api.nvim_buf_is_valid(buf) then
+    return
+  end
   local lines = vim.api.nvim_buf_get_lines(buf, lnum_start, lnum_end, false)
   symbols_parsed['end'].lnum = lnum_start + #lines + 1
 
   for idx, line in ipairs(lines) do
     if line:match('^```') then
       symbols_parsed['end'].inside_code_block =
-        not symbols_parsed['end'].inside_code_block
+          not symbols_parsed['end'].inside_code_block
     end
     if not symbols_parsed['end'].inside_code_block then
       local _, _, heading_notation, heading_str = line:find('^(#+)%s+(.*)')

--- a/lua/dropbar/sources/markdown.lua
+++ b/lua/dropbar/sources/markdown.lua
@@ -30,7 +30,7 @@ end
 ---@field symbols markdown_heading_symbol_t[]
 local markdown_heading_symbols_parsed_list_t = {}
 markdown_heading_symbols_parsed_list_t.__index =
-    markdown_heading_symbols_parsed_list_t
+  markdown_heading_symbols_parsed_list_t
 
 ---Create a new markdown heading symbols parsed object
 ---@param opts markdown_heading_symbols_parsed_list_t?
@@ -49,7 +49,7 @@ local markdown_heading_buf_symbols = {}
 setmetatable(markdown_heading_buf_symbols, {
   __index = function(_, k)
     markdown_heading_buf_symbols[k] =
-        markdown_heading_symbols_parsed_list_t:new()
+      markdown_heading_symbols_parsed_list_t:new()
     return markdown_heading_buf_symbols[k]
   end,
 })
@@ -78,7 +78,7 @@ local function parse_buf(buf, lnum_end, incremental)
   for idx, line in ipairs(lines) do
     if line:match('^```') then
       symbols_parsed['end'].inside_code_block =
-          not symbols_parsed['end'].inside_code_block
+        not symbols_parsed['end'].inside_code_block
     end
     if not symbols_parsed['end'].inside_code_block then
       local _, _, heading_notation, heading_str = line:find('^(#+)%s+(.*)')


### PR DESCRIPTION

![image](https://github.com/Bekaboo/dropbar.nvim/assets/31800073/de4204d1-5f81-48e4-b62c-2a1ed5d4e20d)

Before executing buf_get_lines, add a check to see if the buf_id is valid.