### PR TITLE
fix(symbol): use private data to check for menu

### DIFF
--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -218,8 +218,8 @@ end
 ---Delete a dropbar symbol instance
 ---@return nil
 function dropbar_symbol_t:del()
-  if self.menu then
-    self.menu:del()
+  if self._.menu then
+    self._.menu:del()
   end
 end
 

--- a/lua/dropbar/sources/markdown.lua
+++ b/lua/dropbar/sources/markdown.lua
@@ -61,10 +61,6 @@ setmetatable(markdown_heading_buf_symbols, {
 ---@param incremental? boolean incremental parsing
 ---@return nil
 local function parse_buf(buf, lnum_end, incremental)
-  if not vim.api.nvim_buf_is_valid(buf) then
-    markdown_heading_buf_symbols[buf] = nil
-    return
-  end
   local symbols_parsed = markdown_heading_buf_symbols[buf]
   local lnum_start = symbols_parsed['end'].lnum
   if not incremental then


### PR DESCRIPTION
Avoids triggering lazy-loading of fields when deleting menus which fixes the issue with the markdown source, but also a potentially larger issue for any menu / symbol that makes use of lazy-loading via metatables. My hope is that this will prevent this type of issue from happening in the future even in user-created sources, but there may be some other places where this behavior could occur.

Tests are passing and this seems reasonable to me, but let me know if this will cause issues I'm not aware of.

closes #114