### PR TITLE
fix: remove hover highlight on FocusLost

### DIFF
--- a/lua/dropbar.lua
+++ b/lua/dropbar.lua
@@ -136,6 +136,13 @@ local function setup(opts)
         utils.bar.update_hover_hl(vim.fn.getmousepos())
       end
     end)
+    vim.api.nvim_create_autocmd('FocusLost', {
+      group = groupid,
+      callback = function()
+        utils.bar.update_hover_hl({})
+      end,
+      desc = 'Remove hover highlight on focus lost.',
+    })
   end
   vim.g.loaded_dropbar = true
 end


### PR DESCRIPTION
Makes dropbar aware of multi-monitor and multiplexer setups by clearing hover highlight when the mouse leaves the nvim window.