### PR TITLE
fix(bar): Escape percent signs in symbol_t component names

### DIFF
--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -239,6 +239,7 @@ function dropbar_symbol_t:cat(plain)
     self.cache.plain_str = self.icon .. self.name
     return self.cache.plain_str
   end
+  -- Escape `%` characters to prevent unintended statusline evaluation
   local escaped_name = self.name:gsub('%%', '%%%%')
   local icon_highlighted = hl(self.icon, self.icon_hl)
   local name_highlighted = hl(escaped_name, self.name_hl)

--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -239,8 +239,9 @@ function dropbar_symbol_t:cat(plain)
     self.cache.plain_str = self.icon .. self.name
     return self.cache.plain_str
   end
+  local escaped_name = self.name:gsub('%%', '%%%%')
   local icon_highlighted = hl(self.icon, self.icon_hl)
-  local name_highlighted = hl(self.name, self.name_hl)
+  local name_highlighted = hl(escaped_name, self.name_hl)
   if self.on_click and self.bar_idx then
     self.cache.decorated_str = make_clickable(
       icon_highlighted .. name_highlighted,


### PR DESCRIPTION
Dropbar doesn't currently escape percent signs in component names which can lead to incorrect names when rendered in the winbar:

For example, after `:e \%asdf` (top is dropbar, bottom is default statusline).

![image](https://github.com/Bekaboo/dropbar.nvim/assets/43484729/80355824-d057-4d95-b75b-4ca78e6f1aa8)

Escaping the percent signs before highlighting components seems to fix this:

![image](https://github.com/Bekaboo/dropbar.nvim/assets/43484729/5d6ca7a5-f79c-456e-a210-702cbf1f4c9c)