### PR TITLE
fix(types): add ./lua and $VIMRUNTIME/lua in workspace.library

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -3,6 +3,8 @@
     "workspace": {
         "library": [
             "$VIMRUNTIME",
+            "$VIMRUNTIME/lua",
+            "./lua",
             "${3rd}/busted/library",
             "${3rd}/luassert/library"
         ]
@@ -11,6 +13,8 @@
         "version": "LuaJIT",
         "path": [
             "./?.lua",
+            "./lua/?.lua",
+            "./lua/?/init.lua",
              "/usr/share/luajit-2.1.0-beta3/?.lua",
              "/usr/local/share/lua/5.1/?.lua",
              "/usr/local/share/lua/5.1/?/init.lua",


### PR DESCRIPTION
Makes sure we get proper type checking for Neovim's API and the whole project.