### PR TITLE
fix(event): avoid iterating when table is not exist

### DIFF
--- a/lua/dropbar.lua
+++ b/lua/dropbar.lua
@@ -89,7 +89,7 @@ local function setup(opts)
       group = groupid,
       callback = function(info)
         if info.event == 'WinResized' then
-          for _, win in ipairs(vim.v.event.windows) do
+          for _, win in ipairs(vim.v.event.windows or {}) do
             utils.bar.exec('update', { win = win })
           end
         else


### PR DESCRIPTION
Seems quite impossible, but the window may not exist when `WinSized` is triggered. I don't know the reason but I think avoiding this situation is acceptable.

In my case, this may be because of the plugin:
https://github.com/mikesmithgh/kitty-scrollback.nvim/blob/fd75b297d82e6fb5fe724373cd95d2422b31d7b9/lua/kitty-scrollback/autocommands.lua#L55-L82