### PR TITLE
fix(autocmd): add missing setup event `BufNewFile`

### DIFF
--- a/plugin/dropbar.lua
+++ b/plugin/dropbar.lua
@@ -1,4 +1,4 @@
-vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufWritePost' }, {
+vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile', 'BufWritePost' }, {
   once = true,
   group = vim.api.nvim_create_augroup('DropBarSetup', {}),
   callback = function()


### PR DESCRIPTION
If the user writes a new file by `nvim <new_file_name>`, the `BufReadPost` will not be triggered, instead, `BufNewFile` will be triggered.