### PR TITLE
fix(configs): do not pass filetype directly

### DIFF
--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -15,7 +15,7 @@ M.opts = {
           or (
             buf
               and vim.api.nvim_buf_is_valid(buf)
-              and (pcall(vim.treesitter.get_parser, buf, vim.bo[buf].ft))
+              and (pcall(vim.treesitter.get_parser, buf))
               and true
             or false
           )


### PR DESCRIPTION
There is no need to pass the filetype directly because it has the default value, according to the documentation.
Most importantly, `lang` is the name of the parser instead of the filetype of the buffer, see https://github.com/neovim/neovim/pull/27593
