### PR TITLE
fix(setup): avoid setup twice when using lazy.nvim

### DIFF
--- a/plugin/dropbar.lua
+++ b/plugin/dropbar.lua
@@ -2,6 +2,9 @@ vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile', 'BufWritePost' }, {
   once = true,
   group = vim.api.nvim_create_augroup('DropBarSetup', {}),
   callback = function()
+    if vim.g.loaded_dropbar then
+      return
+    end
     require('dropbar').setup()
   end,
 })


### PR DESCRIPTION
`setup` is execute twice when using `lazy.nvim` load this plugin with `opts = {...}`.

~This is also a workaround for https://github.com/Bekaboo/dropbar.nvim/issues/141.~
