### PR TITLE
fix: add filetype devicon as fallback

### DIFF
--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -27,6 +27,17 @@ local function get_icon_and_hl(path)
         vim.fn.fnamemodify(path, ':e'),
         { default = true }
       )
+      if devicon == nil then
+        ---@type integer|nil
+        local buf = vim.iter(vim.api.nvim_list_bufs()):find(function(buf)
+          return vim.api.nvim_buf_get_name(buf) == path
+        end)
+        if buf then
+          local filetype =
+            vim.api.nvim_get_option_value('filetype', { buf = buf })
+          devicon, devicon_hl = devicons.get_icon_by_filetype(filetype)
+        end
+      end
       icon = devicon and devicon .. ' ' or icon
       icon_hl = devicon_hl
     end

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -27,8 +27,10 @@ local function get_icon_and_hl(path)
         vim.fn.fnamemodify(path, ':e'),
         { default = true }
       )
+      -- No corresponding devicon found using the filename, try finding icon
+      -- with filetype if the file is loaded as a buf in nvim
       if devicon == nil then
-        ---@type integer|nil
+        ---@type integer?
         local buf = vim.iter(vim.api.nvim_list_bufs()):find(function(buf)
           return vim.api.nvim_buf_get_name(buf) == path
         end)


### PR DESCRIPTION
If the devicon does not exist for a filename/extension, we try to find it by the filetype buffer option value first before defaulting to the default icon for a file. This is similar to the behavior for lualine plugin.

This is useful for when the filetype is the buffer not by extension but by other means, e.g. from shebang values or custom filetype plugins.
