### PR TITLE
ci: release-please workflow now requires PAT to trigger push-to-luarocks

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,15 +4,18 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
   release-please:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}
           release-type: simple
           package-name: dropbar.nvim


### PR DESCRIPTION
Bug:    Not triggering push-to-luarocks after release-please.
Fix:    Use personal access token (PAT), see discussion:
	https://github.com/nvim-neorocks/sample-luarocks-plugin/issues/1