### PR TITLE
docs(readme): add build commands to telescope-fzf-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ https://github.com/Bekaboo/dropbar.nvim/assets/76579810/e8c1ac26-0321-4762-9975-
       'Bekaboo/dropbar.nvim',
       -- optional, but required for fuzzy finder support
       dependencies = {
-        'nvim-telescope/telescope-fzf-native.nvim'
+        'nvim-telescope/telescope-fzf-native.nvim',
+        build = 'make'
       }
     }
   })
@@ -187,7 +188,8 @@ https://github.com/Bekaboo/dropbar.nvim/assets/76579810/e8c1ac26-0321-4762-9975-
     use({
       'Bekaboo/dropbar.nvim',
       requires = {
-        'nvim-telescope/telescope-fzf-native.nvim'
+        'nvim-telescope/telescope-fzf-native.nvim',
+        run = 'make'
       }
     })
   end)


### PR DESCRIPTION
These are necessary to correctly install the dependency.