### PR TITLE
feat: Support oil.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1075,6 +1075,10 @@ each sources.
     preview the file under cursor
   - Default: `true`
 
+- `opts.sources.path.oil`: `boolean`
+  - A boolean that enables oil.nvim support
+  - Default: `false`
+
 ##### Treesitter
 
 - `opts.sources.treesitter.max_depth`: `integer`

--- a/doc/dropbar.txt
+++ b/doc/dropbar.txt
@@ -1001,6 +1001,10 @@ PATH                              *dropbar-configuration-options-sources-path*
     preview the file under cursor
   - Default: `true`
 
+- `opts.sources.path.oil`: `boolean`
+  - A boolean that enables oil.nvim support
+  - Default: `false`
+
 TREESITTER                  *dropbar-configuration-options-sources-treesitter*
 
 - `opts.sources.treesitter.max_depth`: `integer`

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -303,7 +303,9 @@ M.opts = {
         return false
       end
 
-      return vim.bo[buf].ft == 'markdown'
+      local ft = vim.bo[buf].ft
+      return ft == 'markdown'
+        or ft == 'oil'
         or pcall(vim.treesitter.get_parser, buf)
         or not vim.tbl_isempty(vim.lsp.get_clients({
           bufnr = buf,

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -288,12 +288,14 @@ M.opts = {
   bar = {
     ---@type boolean|fun(buf: integer, win: integer, info: table?): boolean
     enable = function(buf, win, _)
+      local ft = vim.bo[buf].ft
+
       if
         not vim.api.nvim_buf_is_valid(buf)
         or not vim.api.nvim_win_is_valid(win)
         or vim.fn.win_gettype(win) ~= ''
         or vim.wo[win].winbar ~= ''
-        or vim.bo[buf].ft == 'help'
+        or ft == 'help'
       then
         return false
       end
@@ -304,9 +306,8 @@ M.opts = {
       end
 
       local configs = require('dropbar.configs')
-      local ft = vim.bo[buf].ft
       return ft == 'markdown'
-        or configs.opts.sources.path.oil and ft == 'oil'
+        or (configs.opts.sources.path.oil and ft == 'oil')
         or pcall(vim.treesitter.get_parser, buf)
         or not vim.tbl_isempty(vim.lsp.get_clients({
           bufnr = buf,

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -303,9 +303,10 @@ M.opts = {
         return false
       end
 
+      local configs = require('dropbar.configs')
       local ft = vim.bo[buf].ft
       return ft == 'markdown'
-        or ft == 'oil'
+        or configs.opts.sources.path.oil and ft == 'oil'
         or pcall(vim.treesitter.get_parser, buf)
         or not vim.tbl_isempty(vim.lsp.get_clients({
           bufnr = buf,
@@ -705,6 +706,9 @@ M.opts = {
       end,
       ---@type boolean|fun(path: string): boolean?|nil
       preview = true,
+      ---@type boolean
+      ---Show on oil.nvim buffers
+      oil = false,
     },
     treesitter = {
       max_depth = 16,

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -288,6 +288,7 @@ M.opts = {
   bar = {
     ---@type boolean|fun(buf: integer, win: integer, info: table?): boolean
     enable = function(buf, win, _)
+      local configs = require('dropbar.configs')
       local ft = vim.bo[buf].ft
 
       if
@@ -305,7 +306,6 @@ M.opts = {
         return false
       end
 
-      local configs = require('dropbar.configs')
       return ft == 'markdown'
         or (configs.opts.sources.path.oil and ft == 'oil')
         or pcall(vim.treesitter.get_parser, buf)

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -248,7 +248,7 @@ local function get_symbols(buf, win, _)
     and current_path ~= '.'
     and current_path ~= root
     and current_path ~= vim.fs.dirname(current_path)
-    and (vim.fn.has('win32') == 0 or current_path ~= 'oil:')
+    and not (vim.fn.has('win32') == 1 and current_path == 'oil:')
   do
     table.insert(symbols, 1, convert(current_path, buf, win))
     current_path = vim.fs.dirname(current_path)

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -68,10 +68,12 @@ local function preview(sym)
   end
 
   local lines = not stat and nopreview('Not a file or directory')
+    -- TODO: Windows call
     or stat.type == 'directory' and vim.fn.has('win32') == 0 and vim.fn.systemlist(
       'ls -lhA ' .. vim.fn.shellescape(sym.data.path)
     )
     or stat.size == 0 and nopreview('Empty file')
+    -- TODO: Windows call
     or (vim.fn.has('win32') == 0 and not vim.fn.system({ 'file', sym.data.path }):match('text')) and nopreview(
       'Binary file, no preview available'
     )

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -131,7 +131,7 @@ end
 ---@param win integer window handler
 ---@return dropbar_symbol_t
 local function convert(path, buf, win)
-  -- Fix for oil
+  -- Convert oil.nvim path to system path
   path = path:gsub('^oil:', '/')
 
   local path_opts = configs.opts.sources.path

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -74,9 +74,9 @@ local function preview(sym)
     )
     or stat.size == 0 and nopreview('Empty file')
     -- TODO: Windows call
-    or (vim.fn.has('win32') == 0 and not vim.fn.system({ 'file', sym.data.path }):match('text')) and nopreview(
-      'Binary file, no preview available'
-    )
+    or (vim.fn.has('win32') == 0 and not vim.fn
+      .system({ 'file', sym.data.path })
+      :match('text')) and nopreview('Binary file, no preview available')
     or (function()
         add_syntax = true
         return true

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -72,7 +72,8 @@ local function preview(sym)
       'ls -lhA ' .. vim.fn.shellescape(sym.data.path)
     )
     or stat.size == 0 and nopreview('Empty file')
-    or not vim.fn.system({ 'file', sym.data.path }):match('text') and nopreview(
+    -- TODO: Windows call
+    or (vim.fn.has('win32') == 0 and not vim.fn.system({ 'file', sym.data.path }):match('text')) and nopreview(
       'Binary file, no preview available'
     )
     or (function()

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -131,6 +131,9 @@ end
 ---@param win integer window handler
 ---@return dropbar_symbol_t
 local function convert(path, buf, win)
+  -- Fix for oil
+  path = path:gsub('^oil:', '/')
+
   local path_opts = configs.opts.sources.path
   local icon_opts = configs.opts.icons
   local icon ---@type string?
@@ -148,7 +151,7 @@ local function convert(path, buf, win)
   return bar.dropbar_symbol_t:new(setmetatable({
     buf = buf,
     win = win,
-    name = vim.fs.basename(path),
+    name = (path == '/') and '/' or vim.fs.basename(path),
     icon = icon,
     name_hl = name_hl,
     icon_hl = icon_hl,

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -68,15 +68,13 @@ local function preview(sym)
   end
 
   local lines = not stat and nopreview('Not a file or directory')
-    -- TODO: Windows call
-    or stat.type == 'directory' and vim.fn.has('win32') == 0 and vim.fn.systemlist(
+    or stat.type == 'directory' and vim.fn.systemlist(
       'ls -lhA ' .. vim.fn.shellescape(sym.data.path)
     )
     or stat.size == 0 and nopreview('Empty file')
-    -- TODO: Windows call
-    or (vim.fn.has('win32') == 0 and not vim.fn
-      .system({ 'file', sym.data.path })
-      :match('text')) and nopreview('Binary file, no preview available')
+    or not vim.fn.system({ 'file', sym.data.path }):match('text') and nopreview(
+      'Binary file, no preview available'
+    )
     or (function()
         add_syntax = true
         return true

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -145,14 +145,14 @@ end
 ---@param win integer window handler
 ---@return dropbar_symbol_t
 local function convert(path, buf, win)
+  path = sanitize_oil_path(path)
+
   local path_opts = configs.opts.sources.path
   local icon_opts = configs.opts.icons
   local icon ---@type string?
   local icon_hl ---@type string?
   local name_hl ---@type string?
   local stat = vim.uv.fs_stat(path)
-
-  path = sanitize_oil_path(path)
 
   if stat and stat.type == 'directory' then
     icon, icon_hl = configs.eval(icon_opts.kinds.dir_icon, path)

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -145,7 +145,9 @@ end
 ---@param win integer window handler
 ---@return dropbar_symbol_t
 local function convert(path, buf, win)
-  path = sanitize_oil_path(path)
+  if configs.opts.sources.path.oil then
+    path = sanitize_oil_path(path)
+  end
 
   local path_opts = configs.opts.sources.path
   local icon_opts = configs.opts.icons
@@ -165,7 +167,8 @@ local function convert(path, buf, win)
   return bar.dropbar_symbol_t:new(setmetatable({
     buf = buf,
     win = win,
-    name = (path == '/') and path or vim.fs.basename(path),
+    name = configs.opts.sources.path.oil and ((path == '/') and path)
+      or vim.fs.basename(path),
     icon = icon,
     name_hl = name_hl,
     icon_hl = icon_hl,
@@ -256,6 +259,7 @@ local function get_symbols(buf, win, _)
     and current_path ~= '.'
     and current_path ~= root
     and current_path ~= vim.fs.dirname(current_path)
+    and configs.opts.sources.path.oil
     and not (vim.fn.has('win32') == 1 and current_path == 'oil:')
   do
     table.insert(symbols, 1, convert(current_path, buf, win))

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -253,14 +253,14 @@ local function get_symbols(buf, win, _)
   local symbols = {} ---@type dropbar_symbol_t[]
   local current_path = normalize((vim.api.nvim_buf_get_name(buf)))
   local root = normalize(configs.eval(path_opts.relative_to, buf, win))
+  local is_windows = vim.fn.has('win32') == 1
   while
     #symbols < configs.opts.sources.path.max_depth
     and current_path
     and current_path ~= '.'
     and current_path ~= root
     and current_path ~= vim.fs.dirname(current_path)
-    and configs.opts.sources.path.oil
-    and not (vim.fn.has('win32') == 1 and current_path == 'oil:')
+    and not (is_windows and current_path == 'oil:')
   do
     table.insert(symbols, 1, convert(current_path, buf, win))
     current_path = vim.fs.dirname(current_path)

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -132,7 +132,13 @@ end
 ---@return dropbar_symbol_t
 local function convert(path, buf, win)
   -- Convert oil.nvim path to system path
-  path = path:gsub('^oil:', '/')
+  if path:sub(1, 4) == 'oil:' then
+    if vim.fn.has('win32') == 1 then
+      path = path:gsub('^oil:/([A-Za-z])/', '%1:/'):gsub('^oil:/', '')
+    else
+      path = path:gsub('^oil:', '/')
+    end
+  end
 
   local path_opts = configs.opts.sources.path
   local icon_opts = configs.opts.icons
@@ -240,6 +246,7 @@ local function get_symbols(buf, win, _)
     #symbols < configs.opts.sources.path.max_depth
     and current_path
     and current_path ~= '.'
+    and current_path ~= 'oil:'
     and current_path ~= root
     and current_path ~= vim.fs.dirname(current_path)
   do

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -68,11 +68,10 @@ local function preview(sym)
   end
 
   local lines = not stat and nopreview('Not a file or directory')
-    or stat.type == 'directory' and vim.fn.systemlist(
+    or stat.type == 'directory' and vim.fn.has('win32') == 0 and vim.fn.systemlist(
       'ls -lhA ' .. vim.fn.shellescape(sym.data.path)
     )
     or stat.size == 0 and nopreview('Empty file')
-    -- TODO: Windows call
     or (vim.fn.has('win32') == 0 and not vim.fn.system({ 'file', sym.data.path }):match('text')) and nopreview(
       'Binary file, no preview available'
     )

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -151,7 +151,7 @@ local function convert(path, buf, win)
   return bar.dropbar_symbol_t:new(setmetatable({
     buf = buf,
     win = win,
-    name = (path == '/') and '/' or vim.fs.basename(path),
+    name = (path == '/') and path or vim.fs.basename(path),
     icon = icon,
     name_hl = name_hl,
     icon_hl = icon_hl,

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -125,13 +125,10 @@ local function preview_restore_view(sym)
   end
 end
 
----Convert a path to a dropbar symbol
+---Convert an oil.nvim path to system path
 ---@param path string full path
----@param buf integer buffer handler
----@param win integer window handler
----@return dropbar_symbol_t
-local function convert(path, buf, win)
-  -- Convert oil.nvim path to system path
+---@return string
+local function sanitize_oil_path(path)
   if path:sub(1, 4) == 'oil:' then
     if vim.fn.has('win32') == 1 then
       path = path:gsub('^oil:/([A-Za-z])/', '%1:/'):gsub('^oil:/', '')
@@ -139,13 +136,24 @@ local function convert(path, buf, win)
       path = path:gsub('^oil:', '/')
     end
   end
+  return path
+end
 
+---Convert a path to a dropbar symbol
+---@param path string full path
+---@param buf integer buffer handler
+---@param win integer window handler
+---@return dropbar_symbol_t
+local function convert(path, buf, win)
   local path_opts = configs.opts.sources.path
   local icon_opts = configs.opts.icons
   local icon ---@type string?
   local icon_hl ---@type string?
   local name_hl ---@type string?
   local stat = vim.uv.fs_stat(path)
+
+  path = sanitize_oil_path(path)
+
   if stat and stat.type == 'directory' then
     icon, icon_hl = configs.eval(icon_opts.kinds.dir_icon, path)
     name_hl = 'DropBarKindDir'

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -246,9 +246,9 @@ local function get_symbols(buf, win, _)
     #symbols < configs.opts.sources.path.max_depth
     and current_path
     and current_path ~= '.'
-    and current_path ~= 'oil:'
     and current_path ~= root
     and current_path ~= vim.fs.dirname(current_path)
+    and (vim.fn.has('win32') == 0 or current_path ~= 'oil:')
   do
     table.insert(symbols, 1, convert(current_path, buf, win))
     current_path = vim.fs.dirname(current_path)


### PR DESCRIPTION
This adds support for oil.nvim breadcrumbs. They prepend `oil:` to their paths, and on windows it has non-standard paths like `oil:/C/Users` which need to be converted to `C:/Users` for example.

Had an issue where it had all the directories being treated as files, so this fixes that too.

I handled posix and windows based operating systems.
Tested on mac, linux and windows.

I will add comments to the files.

<img width="550" alt="Screenshot 2025-01-12 at 12 24 55 am" src="https://github.com/user-attachments/assets/b9cd0377-5f56-4009-8d08-0643bf6f2a22" />
