### PR TITLE
Add at least one space after shortcut when in pick mode

### DIFF
--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -536,7 +536,7 @@ function dropbar_t:pick(idx)
       local icon_width = vim.fn.strdisplaywidth(component.icon)
       component:swap_field(
         'icon',
-        shortcut .. string.rep(' ', icon_width - #shortcut)
+        shortcut .. string.rep(' ', string.max(icon_width - #shortcut, 1))
       )
       component:swap_field('icon_hl', 'DropBarIconUIPickPivot')
     end


### PR DESCRIPTION
Hello @Bekaboo,

Thanks for this awesome plugin. I disabled icons for directories in my configuration and noticed that there is a missing space between shortcuts and the folder names in pick mode. I'm proposing to add at least 1 space after the shortcut.

**Before**
<img width="420" alt="image" src="https://github.com/user-attachments/assets/5b042250-084f-407a-9e9f-4cd744ddc273" />

**After**
<img width="528" alt="image" src="https://github.com/user-attachments/assets/3c3ee0e8-9f86-4d53-9fd6-a4543f79f4ac" />

