### PR TITLE
feat(bar): add config `min_widths`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,6 +1073,10 @@ each sources.
   - A boolean or a function that takes a file path and returns whether to
     preview the file under cursor
   - Default: `true`
+- `opts.sources.path.min_widths`: `integer[]`
+  - Minimum width of each symbols when truncated, in reverse order
+    (e.g. `{10}` forces the last symbol has width >= 10)
+  - Default: `{}`
 
 ##### Treesitter
 
@@ -1148,6 +1152,10 @@ each sources.
       'statement',
     }
     ```
+- `opts.sources.treesitter.min_widths`: `integer[]`
+  - Minimum width of each symbols when truncated, in reverse order
+    (e.g. `{10}` forces the last symbol has width >= 10)
+  - Default: `{}`
 
 ##### LSP
 
@@ -1195,6 +1203,10 @@ each sources.
 - `opts.sources.lsp.request.interval`: `number`
   - Number of milliseconds to wait between retries
   - Default: `1000`
+- `opts.sources.lsp.min_widths`: `integer[]`
+  - Minimum width of each symbols when truncated, in reverse order
+    (e.g. `{10}` forces the last symbol has width >= 10)
+  - Default: `{}`
 
 ##### Markdown
 
@@ -1204,6 +1216,10 @@ each sources.
 - `opts.sources.markdown.parse.look_ahead`: `number`
   - Number of lines to update when cursor moves out of the parsed range
   - Default: `200`
+- `opts.sources.markdown.min_widths`: `integer[]`
+  - Minimum width of each symbols when truncated, in reverse order
+    (e.g. `{10}` forces the last symbol has width >= 10)
+  - Default: `{}`
 
 ##### Terminal
 
@@ -1727,6 +1743,7 @@ basic element of [`dropbar_t`](#dropbar_t) and [`dropbar_menu_entry_t`](#dropbar
 | `callback_idx` | `integer?`                                                                                                          | idx of the on_click callback in `_G.dropbar.callbacks[buf][win]`, use this to index callback function because `bar_idx` could change after truncate |
 | `opts`         | `dropbar_symbol_opts_t?`                                                                                            | options passed to `winbar_symbol_t:new()` when the symbols is created                                                                               |
 | `data`         | `table?`                                                                                                            | any extra data associated with the symbol                                                                                                           |
+| `min_width`    | `integer?`                                                                                                          | minimum width when truncated                                                                                                                        |
 
 
 `dropbar_symbol_t` has the following methods:

--- a/doc/dropbar.txt
+++ b/doc/dropbar.txt
@@ -992,6 +992,10 @@ PATH                              *dropbar-configuration-options-sources-path*
   - A boolean or a function that takes a file path and returns whether to
     preview the file under cursor
   - Default: `true`
+- `opts.sources.path.min_widths`: `integer[]`
+  - Minimum width of each symbols when truncated, in reverse order
+    (e.g. `{10}` forces the last symbol has width >= 10)
+  - Default: `{}`
 
 TREESITTER                  *dropbar-configuration-options-sources-treesitter*
 
@@ -1065,6 +1069,10 @@ TREESITTER                  *dropbar-configuration-options-sources-treesitter*
 	      'object',
 	      'statement',
             }
+- `opts.sources.treesitter.min_widths`: `integer[]`
+  - Minimum width of each symbols when truncated, in reverse order
+    (e.g. `{10}` forces the last symbol has width >= 10)
+  - Default: `{}`
 <
 
 LSP                                *dropbar-configuration-options-sources-lsp*
@@ -1112,6 +1120,10 @@ LSP                                *dropbar-configuration-options-sources-lsp*
 - `opts.sources.lsp.request.interval`: `number`
     - Number of milliseconds to wait between retries
     - Default: `1000`
+- `opts.sources.lsp.min_widths`: `integer[]`
+  - Minimum width of each symbols when truncated, in reverse order
+    (e.g. `{10}` forces the last symbol has width >= 10)
+  - Default: `{}`
 
 MARKDOWN                      *dropbar-configuration-options-sources-markdown*
 
@@ -1121,6 +1133,10 @@ MARKDOWN                      *dropbar-configuration-options-sources-markdown*
 - `opts.sources.markdown.parse.look_ahead`: `number`
     - Number of lines to update when cursor moves out of the parsed range
     - Default: `200`
+- `opts.sources.markdown.min_widths`: `integer[]`
+  - Minimum width of each symbols when truncated, in reverse order
+    (e.g. `{10}` forces the last symbol has width >= 10)
+  - Default: `{}`
 
 TERMINAL                      *dropbar-configuration-options-sources-terminal*
 
@@ -2017,6 +2033,13 @@ dropbar_symbol_t.data                                  *dropbar_symbol_t.data*
 
 	Type ~
 	    table?
+
+dropbar_symbol_t.min_width                        *dropbar_symbol_t.min_width*
+
+ 	Minimun width when truncated
+
+	Type ~
+	    integer?
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -36,6 +36,7 @@ end
 ---@field opts dropbar_symbol_opts_t? options passed to `dropbar_symbol_t:new()` when the symbols is created
 ---@field data table? any data associated with the symbol
 ---@field cache table caches string representation, length, etc. for the symbol
+---@field min_width integer? minimum width when truncated
 local dropbar_symbol_t = {}
 
 function dropbar_symbol_t:__index(k)
@@ -345,13 +346,15 @@ function dropbar_t:truncate()
       break
     end
     local name_len = vim.fn.strdisplaywidth(component.name)
-    local min_len =
-      vim.fn.strdisplaywidth(component.name:sub(1, 1) .. self.extends.icon)
+    local min_len = vim.fn.strdisplaywidth(
+      vim.fn.strcharpart(component.name, 0, component.min_width or 1)
+        .. self.extends.icon
+    )
     if name_len > min_len then
       component.name = vim.fn.strcharpart(
         component.name,
         0,
-        math.max(1, name_len - delta - 1)
+        math.max(component.min_width or 1, name_len - delta - 1)
       ) .. self.extends.icon
       delta = delta - name_len + vim.fn.strdisplaywidth(component.name)
     end

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -692,6 +692,8 @@ M.opts = {
       end,
       ---@type boolean|fun(path: string): boolean?|nil
       preview = true,
+      ---@type integer[]
+      min_widths = {}
     },
     treesitter = {
       max_depth = 16,
@@ -763,6 +765,8 @@ M.opts = {
         'object',
         'statement',
       },
+      ---@type integer[]
+      min_widths = {}
     },
     lsp = {
       max_depth = 16,
@@ -799,6 +803,8 @@ M.opts = {
         ttl_init = 60,
         interval = 1000, -- in ms
       },
+      ---@type integer[]
+      min_widths = {}
     },
     markdown = {
       max_depth = 6,
@@ -806,6 +812,8 @@ M.opts = {
         -- Number of lines to update when cursor moves out of the parsed range
         look_ahead = 200,
       },
+      ---@type integer[]
+      min_widths = {}
     },
     terminal = {
       ---@type string|fun(buf: integer): string?

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -693,7 +693,7 @@ M.opts = {
       ---@type boolean|fun(path: string): boolean?|nil
       preview = true,
       ---@type integer[]
-      min_widths = {}
+      min_widths = {},
     },
     treesitter = {
       max_depth = 16,
@@ -766,7 +766,7 @@ M.opts = {
         'statement',
       },
       ---@type integer[]
-      min_widths = {}
+      min_widths = {},
     },
     lsp = {
       max_depth = 16,
@@ -804,7 +804,7 @@ M.opts = {
         interval = 1000, -- in ms
       },
       ---@type integer[]
-      min_widths = {}
+      min_widths = {},
     },
     markdown = {
       max_depth = 6,
@@ -813,7 +813,7 @@ M.opts = {
         look_ahead = 200,
       },
       ---@type integer[]
-      min_widths = {}
+      min_widths = {},
     },
     terminal = {
       ---@type string|fun(buf: integer): string?

--- a/lua/dropbar/sources/lsp.lua
+++ b/lua/dropbar/sources/lsp.lua
@@ -1,5 +1,6 @@
 local configs = require('dropbar.configs')
 local bar = require('dropbar.bar')
+local utils = require('dropbar.utils')
 local groupid = vim.api.nvim_create_augroup('DropBarLsp', {})
 local initialized = false
 
@@ -408,6 +409,7 @@ local function get_symbols(buf, win, cursor)
   end
   local result = {}
   convert_document_symbol_list(lsp_buf_symbols[buf], result, buf, win, cursor)
+  utils.bar.set_min_widths(result, configs.opts.sources.lsp.min_widths)
   return result
 end
 

--- a/lua/dropbar/sources/markdown.lua
+++ b/lua/dropbar/sources/markdown.lua
@@ -1,5 +1,6 @@
 local configs = require('dropbar.configs')
 local bar = require('dropbar.bar')
+local utils = require('dropbar.utils')
 
 local initialized = false
 local groupid = vim.api.nvim_create_augroup('DropBarMarkdown', {})
@@ -319,6 +320,7 @@ local function get_symbols(buf, win, cursor)
       end
     end
   end
+  utils.bar.set_min_widths(result, configs.opts.sources.markdown.min_widths)
   return result
 end
 

--- a/lua/dropbar/sources/path.lua
+++ b/lua/dropbar/sources/path.lua
@@ -1,5 +1,6 @@
 local configs = require('dropbar.configs')
 local bar = require('dropbar.bar')
+local utils = require('dropbar.utils')
 
 ---Normalize executable path
 ---If `cmd` is executable, it is returned as is; else we try to find it under
@@ -311,6 +312,7 @@ local function get_symbols(buf, win, _)
   if vim.bo[buf].mod then
     symbols[#symbols] = path_opts.modified(symbols[#symbols])
   end
+  utils.bar.set_min_widths(symbols, path_opts.min_widths)
   return symbols
 end
 

--- a/lua/dropbar/sources/treesitter.lua
+++ b/lua/dropbar/sources/treesitter.lua
@@ -1,5 +1,6 @@
 local configs = require('dropbar.configs')
 local bar = require('dropbar.bar')
+local utils = require('dropbar.utils')
 
 ---Convert a snake_case string to camelCase
 ---@param str string?
@@ -179,6 +180,7 @@ local function get_symbols(buf, win, cursor)
     node = node:parent()
   end
 
+  utils.bar.set_min_widths(symbols, configs.opts.sources.treesitter.min_widths)
   return symbols
 end
 

--- a/lua/dropbar/utils/bar.lua
+++ b/lua/dropbar/utils/bar.lua
@@ -130,4 +130,16 @@ function M.attach(buf, win, info)
   end
 end
 
+---Set min widths for dropbar symbols
+---@param symbols dropbar_symbol_t[]
+---@param min_widths integer[]
+function M.set_min_widths(symbols, min_widths)
+  for i, w in ipairs(min_widths) do
+    if i > #symbols then
+      break
+    end
+    symbols[#symbols - i + 1].min_width = w
+  end
+end
+
 return M


### PR DESCRIPTION
Add config `min_widths` to config minimum width of dropbar symbols when truncated.

For example, setting `sources.path.min_widths = {20, 10}` forces the last symbol of path (which is filename) has width at least 20 when it is truncated, and the last but one (which is parent directory name) has width at least 10.

Add this config for souces path, lsp, treesitter and markdown.