### PR TITLE
separate highlights for current context icon and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,8 @@ colorscheme to change the appearance of the drop-down menu:
 | Highlight group                    | Description                                                          | Attributes                                 |
 | ---------------------------------- | -------------------------------------------------------------        | ------------------------------------------ |
 | DropBarCurrentContext              | Background of selected/clicked symbol in dropbar                     | `{ link = 'Visual' }`                      |
+| DropBarCurrentContextIcon          | Highlight for selected/clicked symbol's icon in dropbar              | `{ link = 'DropBarCurrentContext' }`       |
+| DropBarCurrentContextName          | Highlight for selected/clicked symbol's name in dropbar              | `{ link = 'DropBarCurrentContext' }`       |
 | DropBarFzfMatch                    | Fzf fuzzy search matches                                             | `{ link = 'Special' }`                     |
 | DropBarHover                       | Background of the dropbar symbol when the mouse is hovering over it  | `{ link = 'Visual' }`                      |
 | DropBarIconKindDefault             | Default highlight for dropbar icons                                  | `{ link = 'Special' }`                     |
@@ -1199,7 +1201,7 @@ colorscheme to change the appearance of the drop-down menu:
 | DropBarMenuHoverEntry              | Background of hovered line in dropbar menus                          | `{ link = 'IncSearch' }`                   |
 | DropBarMenuHoverIcon               | Background of hovered symbol icon in dropbar menus                   | `{ reverse = true }`                       |
 | DropBarMenuHoverSymbol             | Background of hovered symbol name in dropbar menus                   | `{ bold = true }`                          |
-| DropBarMenuNormalFloat             | Nomral text in dropbar menus                                         | `{ link = 'NormalFloat' }`                 |
+| DropBarMenuNormalFloat             | Normal text in dropbar menus                                         | `{ link = 'NormalFloat' }`                 |
 | DropBarMenuSbar                    | Scrollbar background of dropbar menus                                | `{ link = 'PmenuSbar' }`                   |
 | DropBarMenuThumb                   | Scrollbar thumb of dropbar menus                                     | `{ link = 'PmenuThumb' }`                  |
 | DropBarPreview                     | Range of the symbol under the cursor in source code                  | `{ link = 'Visual' }`                      |

--- a/doc/dropbar.txt
+++ b/doc/dropbar.txt
@@ -1,4 +1,4 @@
-*dropbar.txt*                                         Last change: 2025 May 12
+*dropbar.txt*                                         Last change: 2025 May 19
 
 ==============================================================================
 INTRODUCTION                                            *dropbar-introduction*
@@ -1116,6 +1116,8 @@ colorscheme to change the appearance of the drop-down menu:
 | Highlight group                    | Description                                                          | Attributes                                 |
 | ---------------------------------- | -------------------------------------------------------------        | ------------------------------------------ |
 | DropBarCurrentContext              | Background of selected/clicked symbol in dropbar                     | `{ link = 'Visual' }`                      |
+| DropBarCurrentContextIcon          | Highlight for selected/clicked symbol's icon in dropbar              | `{ link = 'DropBarCurrentContext' }`       |
+| DropBarCurrentContextName          | Highlight for selected/clicked symbol's name in dropbar              | `{ link = 'DropBarCurrentContext' }`       |
 | DropBarFzfMatch                    | Fzf fuzzy search matches                                             | `{ link = 'Special' }`                     |
 | DropBarHover                       | Background of the dropbar symbol when the mouse is hovering over it  | `{ link = 'Visual' }`                      |
 | DropBarIconKindDefault             | Default highlight for dropbar icons                                  | `{ link = 'Special' }`                     |
@@ -1131,7 +1133,7 @@ colorscheme to change the appearance of the drop-down menu:
 | DropBarMenuHoverEntry              | Background of hovered line in dropbar menus                          | `{ link = 'IncSearch' }`                   |
 | DropBarMenuHoverIcon               | Background of hovered symbol icon in dropbar menus                   | `{ reverse = true }`                       |
 | DropBarMenuHoverSymbol             | Background of hovered symbol name in dropbar menus                   | `{ bold = true }`                          |
-| DropBarMenuNormalFloat             | Nomral text in dropbar menus                                         | `{ link = 'NormalFloat' }`                 |
+| DropBarMenuNormalFloat             | Normal text in dropbar menus                                         | `{ link = 'NormalFloat' }`                 |
 | DropBarMenuSbar                    | Scrollbar background of dropbar menus                                | `{ link = 'PmenuSbar' }`                   |
 | DropBarMenuThumb                   | Scrollbar thumb of dropbar menus                                     | `{ link = 'PmenuThumb' }`                  |
 | DropBarPreview                     | Range of the symbol under the cursor in source code                  | `{ link = 'Visual' }`                      |

--- a/lua/dropbar/bar.lua
+++ b/lua/dropbar/bar.lua
@@ -644,12 +644,12 @@ function dropbar_t:update_current_context_hl(bar_idx)
   vim.api.nvim_set_hl(
     0,
     hl_currentcontext_icon,
-    utils.hl.merge('WinBarNC', symbol.icon_hl, 'DropBarCurrentContext')
+    utils.hl.merge('WinBarNC', symbol.icon_hl, 'DropBarCurrentContextIcon')
   )
   vim.api.nvim_set_hl(
     0,
     hl_currentcontext_name,
-    utils.hl.merge('WinBarNC', symbol.name_hl, 'DropBarCurrentContext')
+    utils.hl.merge('WinBarNC', symbol.name_hl, 'DropBarCurrentContextName')
   )
   symbol:swap_field('icon_hl', hl_currentcontext_icon)
   symbol:swap_field('name_hl', hl_currentcontext_name)

--- a/lua/dropbar/hlgroups.lua
+++ b/lua/dropbar/hlgroups.lua
@@ -1,6 +1,8 @@
 -- stylua: ignore start
 local hlgroups = {
   DropBarCurrentContext            = { link = 'Visual' },
+  DropBarCurrentContextIcon        = { link = 'DropBarCurrentContext' },
+  DropBarCurrentContextName        = { link = 'DropBarCurrentContext' },
   DropBarFzfMatch                  = { link = 'Special' },
   DropBarHover                     = { link = 'Visual' },
   DropBarIconKindDefault           = { link = 'Special' },


### PR DESCRIPTION
I'm working on a colorscheme and needed to separate these two highlights to get the bar looking the way I wanted. Before this change, setting a `fg` color on the `DropBarCurrentContext` highlight group would override the icon's highlight