### PR TITLE
fix: nvim 0.12 `vim.treesitter.get_parser` api changed

### DIFF
--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -289,7 +289,10 @@ M.opts = {
 
       return vim.bo[buf].bt == 'terminal'
         or vim.bo[buf].ft == 'markdown'
-        or pcall(vim.treesitter.get_parser, buf)
+        or (function()
+          local ok, parser = pcall(vim.treesitter.get_parser, buf)
+          return ok and parser ~= nil
+        end)()
         or not vim.tbl_isempty(vim.lsp.get_clients({
           bufnr = buf,
           method = 'textDocument/documentSymbol',


### PR DESCRIPTION
In nvim 0.11, if current buffer does not have any parser, `vim.treesitter.get_parser(buf)` throws lua error, so `pcall` will return `false`.
In nvim 0.12, in the same situation, `vim.treesitter.get_parser(buf)` returns nil and an error message, so `pcall` will always return `true`.
That's why the default `enable` function returns `true` for many filetypes which should not show the dropbar.
Sees https://neovim.io/doc/user/news-0.12/#_removed-features.

This modification is compatible with nvim 0.11 and before.

fixes #274 