### PR TITLE
fix: clear dropbar when enable() returns false

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,11 @@ winbar:
       end
 
       if
-        not vim.api.nvim_buf_is_valid(buf)
-        or not vim.api.nvim_win_is_valid(win)
-        or vim.fn.win_gettype(win) ~= ''
+        vim.fn.win_gettype(win) ~= ''
         or vim.wo[win].winbar ~= ''
         or vim.bo[buf].ft == 'help'
       then
+        vim.wo[win].winbar = nil
         return false
       end
 

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -273,12 +273,11 @@ M.opts = {
       end
 
       if
-        not vim.api.nvim_buf_is_valid(buf)
-        or not vim.api.nvim_win_is_valid(win)
-        or vim.fn.win_gettype(win) ~= ''
+        vim.fn.win_gettype(win) ~= ''
         or vim.wo[win].winbar ~= ''
         or vim.bo[buf].ft == 'help'
       then
+        vim.wo[win].winbar = nil
         return false
       end
 


### PR DESCRIPTION
fix: clear winbar when enable() returns false

Previously, opening windows such as `:help` or Outline would still display the dropbar. Testing showed that `opts.bar.enable` correctly returns `false` for these windows, but the winbar itself was not cleared in a timely manner.

This commit adds a winbar cleanup step when the enable function determines that dropbar should be disabled, ensuring
the UI correctly reflects the intended state.

And I noticed there were duplicate conditional statements, I keep the first one to determine whether the `buf` and `win` 
are valid. I remove the same conditions in the second statements.

Also, I modified the corresponding reference configuration text in `README.md`.

Closes #277