### PR TITLE
fix: replace deprecated event BufModifiedSet with OptionSet

### DIFF
--- a/doc/dropbar.txt
+++ b/doc/dropbar.txt
@@ -246,7 +246,7 @@ the winbar:
   trigger an update on all dropbars attached to a buffer - Default:
 >lua
     {
-          'BufModifiedSet',
+          'OptionSet',
           'FileChangedShellPost',
           'TextChanged',
           'ModeChanged',

--- a/lua/dropbar.lua
+++ b/lua/dropbar.lua
@@ -109,6 +109,7 @@ local function setup(opts)
 
   if not vim.tbl_isempty(configs.opts.bar.update_events.buf) then
     vim.api.nvim_create_autocmd(configs.opts.bar.update_events.buf, {
+      pattern = 'modified',
       group = groupid,
       callback = function(args)
         utils.bar.exec('update', { buf = args.buf })

--- a/lua/dropbar/configs.lua
+++ b/lua/dropbar/configs.lua
@@ -320,7 +320,7 @@ M.opts = {
         'WinResized',
       },
       buf = {
-        'BufModifiedSet',
+        'OptionSet',
         'FileChangedShellPost',
         'TextChanged',
         'ModeChanged',


### PR DESCRIPTION
https://github.com/Bekaboo/dropbar.nvim/issues/279